### PR TITLE
Use title as output filename

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -4,6 +4,7 @@ use crate::dezoomer::Dezoomer;
 
 use super::{auto, stdin_line, Vec2d, ZoomError};
 use std::time::Duration;
+use std::path::PathBuf;
 use regex::Regex;
 
 #[derive(StructOpt, Debug)]
@@ -13,8 +14,8 @@ pub struct Arguments {
     input_uri: Option<String>,
 
     /// File to which the resulting image should be saved
-    #[structopt(default_value = "dezoomified.jpg")]
-    pub outfile: std::path::PathBuf,
+    #[structopt(parse(from_os_str))]
+    pub outfile: Option<PathBuf>,
 
     /// Name of the dezoomer to use
     #[structopt(short, long, default_value = "auto")]

--- a/src/dezoomer.rs
+++ b/src/dezoomer.rs
@@ -100,6 +100,9 @@ pub trait TileProvider: Debug {
     fn name(&self) -> String {
         format!("{:?}", self)
     }
+    fn title(&self) -> String {
+        format!("{:?}", self)
+    }
     fn size_hint(&self) -> Option<Vec2d> {
         None
     }
@@ -189,6 +192,11 @@ impl<T: TilesRect> TileProvider for T {
             self.tile_count()
         )
     }
+
+    fn title(&self) -> String {
+        format!("{:?}", self)
+    }
+
     fn size_hint(&self) -> Option<Vec2d> {
         Some(self.size())
     }

--- a/src/dezoomer.rs
+++ b/src/dezoomer.rs
@@ -100,9 +100,7 @@ pub trait TileProvider: Debug {
     fn name(&self) -> String {
         format!("{:?}", self)
     }
-    fn title(&self) -> String {
-        format!("{:?}", self)
-    }
+    fn title(&self) -> Option<String> { None }
     fn size_hint(&self) -> Option<Vec2d> {
         None
     }
@@ -146,6 +144,7 @@ pub trait TilesRect: Debug {
     fn size(&self) -> Vec2d;
     fn tile_size(&self) -> Vec2d;
     fn tile_url(&self, pos: Vec2d) -> String;
+    fn title(&self) -> Option<String> { None }
     fn tile_ref(&self, pos: Vec2d) -> TileReference {
         TileReference {
             url: self.tile_url(pos),
@@ -193,13 +192,11 @@ impl<T: TilesRect> TileProvider for T {
         )
     }
 
-    fn title(&self) -> String {
-        format!("{:?}", self)
-    }
-
     fn size_hint(&self) -> Option<Vec2d> {
         Some(self.size())
     }
+
+    fn title(&self) -> Option<String> { TilesRect::title(self) }
 
     fn http_headers(&self) -> HashMap<String, String> {
         let mut headers = HashMap::new();

--- a/src/google_arts_and_culture/mod.rs
+++ b/src/google_arts_and_culture/mod.rs
@@ -87,6 +87,10 @@ impl TilesRect for GAPZoomLevel {
     fn post_process_fn(&self) -> PostProcessFn {
         PostProcessFn::Fn(post_process_tile)
     }
+
+    fn title(&self) -> Option<String> {
+        Some(format!("{:?}", self))
+    }
 }
 
 fn post_process_tile(_tile: &TileReference, data: Vec<u8>) -> Result<Vec<u8>, Box<dyn Error + Send + 'static>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,23 +65,21 @@ async fn main() {
 // - create directories in path if needed (current behaviour 
 //   assumes that path exists)
 fn get_outname(uri: String, outfile: Option<PathBuf>, zoom_name: &str) -> PathBuf {
-    if outfile.is_none() && uri.contains("artsandculture.google.com") {
-        let mut outname = zoom_name.replace(&['(', ')', ',', '\"', '.', ';', ':', '\''][..], "");
-        let fixed_ext = ".jpg".to_string();
-        outname.push_str(&fixed_ext);
-        return PathBuf::from(outname);
+    if let Some(path) = outfile {
+        if path.extension().is_none() {
+            path.with_extension("jpg")
+        } else {
+            path
+        }
+    } else {
+        let mut outname = if uri.contains("artsandculture.google.com") {
+            zoom_name.replace(&['(', ')', ',', '\"', '.', ';', ':', '\''][..], "")
+        } else {
+            String::from("dezoomified")
+        };
+        outname.push_str(".jpg");
+        PathBuf::from(outname)
     }
-
-    if outfile.is_none() {
-        let default_name = "dezoomified.jpg".to_string();
-        return PathBuf::from(default_name);
-    }
-
-    if outfile.is_some() && !outfile.as_deref().unwrap().ends_with(".jpg") {
-        return outfile.unwrap().with_extension("jpg");
-    }
-
-    return outfile.unwrap();
 }
 
 // TODO: return Bytes

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ async fn main() {
 // - append _1,_2,.. suffix to `outname` if file already exist
 // - create directories in path if needed (current behaviour 
 //   assumes that path exists)
-fn get_outname(uri: String, outfile: Option<PathBuf>, zoom_name: &str) -> PathBuf {
+fn get_outname(outfile: Option<PathBuf>, zoom_name: &Option<String>) -> PathBuf {
     if let Some(path) = outfile {
         if path.extension().is_none() {
             path.with_extension("jpg")
@@ -72,8 +72,8 @@ fn get_outname(uri: String, outfile: Option<PathBuf>, zoom_name: &str) -> PathBu
             path
         }
     } else {
-        let mut outname = if uri.contains("artsandculture.google.com") {
-            zoom_name.replace(&['(', ')', ',', '\"', '.', ';', ':', '\''][..], "")
+        let mut outname = if let Some(name) = zoom_name {
+            name.replace(&['(', ')', ',', '\"', '.', ';', ':', '\''][..], "")
         } else {
             String::from("dezoomified")
         };
@@ -255,7 +255,7 @@ async fn dezoomify(args: Arguments) -> Result<(), ZoomError> {
     progress.finish_with_message(&final_msg);
 
     let canvas = canvas.lock().unwrap();
-    let outname = get_outname(args.choose_input_uri(), args.outfile, &zoom_level.title());
+    let outname = get_outname(args.outfile, &zoom_level.title());
 
     println!("Saving the image to {}...", outname.as_path().to_string_lossy());
     canvas.image().save(outname.as_path())?;


### PR DESCRIPTION
The default behaviour for output filename is to save it
as 'dezoomified.jpg', but for cases when information for
title is available (e.g. for Google Arts & Culture) we can
use this as output filename.

Summary of changes included:

 - change Argument outfile to type `Option<PathBuf>`

 - add `fn title` to `TileProvider`, for providing the
   information of current dezoomify title

 - add `fn get_outname`, for changing the output filename.

 - fix override output file extension to 'jpg'

Resolves: #20