### PR TITLE
when re-tiling images in the experimental IIIF format make JPEG quality configurable

### DIFF
--- a/src/encoder/iiif_encoder.rs
+++ b/src/encoder/iiif_encoder.rs
@@ -1,6 +1,6 @@
 use std::fs::OpenOptions;
 use std::io;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use image::{ImageOutputFormat};

--- a/src/encoder/iiif_encoder.rs
+++ b/src/encoder/iiif_encoder.rs
@@ -26,7 +26,7 @@ impl IiifEncoder {
         let _ = std::fs::remove_file(&destination);
         debug!("Creating IIIF  directory at {:?}", &destination);
         std::fs::create_dir(&destination)?;
-        let tile_saver = IIIFTileSaver { root_path: destination.clone(), quality: quality };
+        let tile_saver = IIIFTileSaver { root_path: destination.clone(), quality };
         let tile_size = Vec2d::square(512);
         Ok(IiifEncoder {
             retiler: Retiler::new(size, tile_size, Arc::new(tile_saver), 1),

--- a/src/encoder/iiif_encoder.rs
+++ b/src/encoder/iiif_encoder.rs
@@ -3,6 +3,8 @@ use std::io;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
+use image::{ImageOutputFormat};
+use std::fs::File;
 
 use log::debug;
 
@@ -20,11 +22,11 @@ pub struct IiifEncoder {
 }
 
 impl IiifEncoder {
-    pub fn new(destination: PathBuf, size: Vec2d) -> Result<Self, ZoomError> {
+    pub fn new(destination: PathBuf, size: Vec2d, quality: u8) -> Result<Self, ZoomError> {
         let _ = std::fs::remove_file(&destination);
         debug!("Creating IIIF  directory at {:?}", &destination);
         std::fs::create_dir(&destination)?;
-        let tile_saver = IIIFTileSaver { root_path: destination.clone() };
+        let tile_saver = IIIFTileSaver { root_path: destination.clone(), quality: quality };
         let tile_size = Vec2d::square(512);
         Ok(IiifEncoder {
             retiler: Retiler::new(size, tile_size, Arc::new(tile_saver), 1),
@@ -88,6 +90,7 @@ impl Encoder for IiifEncoder {
 
 struct IIIFTileSaver {
     root_path: PathBuf,
+    quality: u8,
 }
 
 impl TileSaver for IIIFTileSaver {
@@ -106,6 +109,7 @@ impl TileSaver for IIIFTileSaver {
         let image_path = image_dir_path.join(filename);
         debug!("Writing tile to {:?}", image_path);
         std::fs::create_dir_all(&image_dir_path)?;
-        tile.image.save(image_path).map_err(image_error_to_io_error)
+	let mut file = File::create(&image_path)?;
+	tile.image.write_to(&mut file, ImageOutputFormat::Jpeg(self.quality)).map_err(image_error_to_io_error)
     }
 }

--- a/src/encoder/iiif_encoder.rs
+++ b/src/encoder/iiif_encoder.rs
@@ -109,7 +109,7 @@ impl TileSaver for IIIFTileSaver {
         let image_path = image_dir_path.join(filename);
         debug!("Writing tile to {:?}", image_path);
         std::fs::create_dir_all(&image_dir_path)?;
-	let mut file = File::create(&image_path)?;
-	tile.image.write_to(&mut file, ImageOutputFormat::Jpeg(self.quality)).map_err(image_error_to_io_error)
+	let file = &mut BufWriter::new(File::create(&image_path)?);
+	tile.image.write_to(file, ImageOutputFormat::Jpeg(self.quality)).map_err(image_error_to_io_error)
     }
 }

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -30,7 +30,8 @@ fn encoder_for_name(destination: PathBuf, size: Vec2d, compression: u8) -> Resul
         Ok(Box::new(png_encoder::PngEncoder::new(destination, size, compression)?))
     } else if extension == "iiif" {
         debug!("Using the iiif tiling encoder");
-        Ok(Box::new(iiif_encoder::IiifEncoder::new(destination, size)?))
+	let quality = 100u8.saturating_sub(compression);
+        Ok(Box::new(iiif_encoder::IiifEncoder::new(destination, size, quality)?))
     } else if extension == "jpeg" || extension == "jpg" {
         debug!("Using the jpeg encoder with a quality of {}", compression);
         let image_writer = ImageWriter::Jpeg { quality: 100u8.saturating_sub(compression) };


### PR DESCRIPTION
This change extends the recent 'compression' flag so that the JPEG quality of tiles output in the experimental IIIF format are also affected.