### PR TITLE
Parse URL field in '.dzi' file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
 dependencies = [
  "block-cipher",
  "byteorder",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -50,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
 dependencies = [
  "block-cipher",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -141,11 +141,23 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding 0.1.5",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -154,7 +166,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -164,7 +176,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9b14fd8a4739e6548d4b6018696cf991dcf8c6effd9ef9eb33b29b8a650972"
 dependencies = [
  "block-cipher",
- "block-padding",
+ "block-padding 0.2.1",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -190,6 +211,12 @@ name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
@@ -431,7 +458,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -493,6 +520,7 @@ dependencies = [
  "img_hash",
  "indicatif",
  "itertools",
+ "json5",
  "lazy_static",
  "log",
  "png",
@@ -504,10 +532,19 @@ dependencies = [
  "serde_json",
  "serde_urlencoded 0.7.0",
  "serde_yaml",
- "sha-1",
+ "sha-1 0.9.1",
  "structopt",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -516,7 +553,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -564,6 +601,12 @@ name = "evalexpr"
 version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a8619223d40c23279f9120e2646712ec3eeeb68b546ed993c619d77682bdef8"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fixedbitset"
@@ -727,6 +770,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -737,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -818,7 +870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1023,6 +1075,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb2522ff59fbfefb955e9bd44d04d5e5c2d0e8865bfc2c3d1ab3916183ef5ee"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1136,12 @@ name = "lzw"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
@@ -1282,6 +1351,12 @@ checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
 
 [[package]]
 name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -1357,6 +1432,49 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
+]
 
 [[package]]
 name = "pin-project"
@@ -1839,15 +1957,27 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpuid-bool",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2182,6 +2312,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 serde-xml-rs = "0.4"
 serde_json = "1.0"
+json5 = "0.2"
 serde_urlencoded = "0.7"
 block-modes = "0.6"
 aes = "0.5"

--- a/src/dzi/dzi_file.rs
+++ b/src/dzi/dzi_file.rs
@@ -14,12 +14,8 @@ pub struct DziFile {
     pub format: String,
     #[serde(rename = "Size", default)]
     pub sizes: Vec<Size>,
-    #[serde(rename = "Url", default = "no_url")]
-    pub base_url: String,
-}
-
-fn no_url() -> String {
-    "no url".to_string()
+    #[serde(rename = "Url")]
+    pub base_url: Option<String>,
 }
 
 impl DziFile {
@@ -33,6 +29,19 @@ impl DziFile {
     pub fn max_level(&self) -> u32 {
         let size = self.get_size().unwrap();
         log2(size.x.max(size.y))
+    }
+
+    /// Compute the base URL for tiles. If a base URL is specified in this structure, remove it
+    pub fn take_base_url(&mut self, resource_url: &str) -> String {
+        if let Some(mut url_str) = self.base_url.take() {
+            if url_str.ends_with('/') { url_str.pop(); }
+            url_str
+        } else {
+            let until_dot = if let Some(dot_pos) = resource_url.rfind('.') {
+                &resource_url[0..dot_pos]
+            } else { resource_url };
+            format!("{}_files", until_dot)
+        }
     }
 }
 

--- a/src/dzi/dzi_file.rs
+++ b/src/dzi/dzi_file.rs
@@ -14,6 +14,12 @@ pub struct DziFile {
     pub format: String,
     #[serde(rename = "Size", default)]
     pub sizes: Vec<Size>,
+    #[serde(rename = "Url", default = "no_url")]
+    pub base_url: String,
+}
+
+fn no_url() -> String {
+    "no url".to_string()
 }
 
 impl DziFile {

--- a/src/dzi/mod.rs
+++ b/src/dzi/mod.rs
@@ -50,8 +50,8 @@ fn load_from_properties(url: &str, contents: &[u8]) -> Result<ZoomLevels, DziErr
         .and_then(|dzi| load_from_dzi(url, dzi))
         .or_else(|e| {
             let levels: Vec<ZoomLevel> = all_json::<DziJsonFile>(contents)
-                .flat_map(|dzi| load_from_dzi(url, dzi).into_iter())
-                .flat_map(|levels| levels.into_iter())
+                .flat_map(|dzi| load_from_dzi(url, dzi))
+                .flatten()
                 .collect();
             if levels.is_empty() { Err(e) } else { Ok(levels) }
         })

--- a/src/dzi/mod.rs
+++ b/src/dzi/mod.rs
@@ -127,11 +127,17 @@ impl TilesRect for DziLevel {
             position: self.tile_size() * pos - delta,
         }
     }
+
+    fn title(&self) -> Option<String> {
+        let suffix = self.base_url.rsplitn(2, '/').next().unwrap_or("");
+        let name = suffix.trim_end_matches("_files");
+        Some(name.to_string())
+    }
 }
 
 impl std::fmt::Debug for DziLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Deep Zoom Image")
+        write!(f, "{} (Deep Zoom Image)", TileProvider::title(self).unwrap_or_default())
     }
 }
 

--- a/src/dzi/mod.rs
+++ b/src/dzi/mod.rs
@@ -48,7 +48,15 @@ fn load_from_properties(url: &str, contents: &[u8]) -> Result<ZoomLevels, DziErr
     }
 
     let dot_pos = url.rfind('.').unwrap_or(url.len() - 1);
-    let base_url = &Arc::new(format!("{}_files", &url[0..dot_pos]));
+    let mut url_str =  if image_properties.base_url.eq("no url") {  
+	format!("{}_files", &url[0..dot_pos])
+    } else {
+	image_properties.base_url.clone()
+    };
+    if url_str.ends_with('/') {
+	url_str.pop();
+    }
+    let base_url = &Arc::new(url_str);
 
     let size = image_properties.get_size()?;
     let max_level = image_properties.max_level();

--- a/src/json_utils.rs
+++ b/src/json_utils.rs
@@ -1,0 +1,90 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer};
+
+/// An iterator over pairs of matching '{' and '}'
+struct IterJson<'a> {
+    s: &'a [u8],
+    start_pos: Vec<usize>,
+    current_pos: usize,
+}
+
+impl<'a> IterJson<'a> {
+    fn new(s: &'a [u8]) -> Self {
+        let start_pos = Vec::with_capacity(8);
+        IterJson { s, start_pos, current_pos: 0 }
+    }
+}
+
+impl<'a> Iterator for IterJson<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(c) = self.s.get(self.current_pos) {
+            match c {
+                b'{' => { self.start_pos.push(self.current_pos) }
+                b'}' => {
+                    if let Some(start) = self.start_pos.pop() {
+                        self.current_pos += 1;
+                        return Some(&self.s[start..self.current_pos]);
+                    }
+                }
+                _ => {}
+            }
+            self.current_pos += 1;
+        }
+        None
+    }
+}
+
+/// Return an iterator over all JSON values that can be deserialized in the given byte buffer
+pub fn all_json<'a, T>(bytes: &'a [u8]) -> impl Iterator<Item=T> + 'a
+    where T: Deserialize<'a> + 'a {
+    IterJson::new(bytes)
+        .flat_map(|bytes| std::str::from_utf8(bytes).into_iter())
+        .flat_map(|x| json5::from_str(x).into_iter())
+}
+
+
+/// Deserializer for fields that can be a number or a string representation of the number
+pub fn number_or_string<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: FromStr + serde::Deserialize<'de>,
+        <T as FromStr>::Err: Display,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt<T> {
+        String(String),
+        Number(T),
+    }
+
+    match StringOrInt::<T>::deserialize(deserializer)? {
+        StringOrInt::String(s) => s.parse::<T>().map_err(serde::de::Error::custom),
+        StringOrInt::Number(i) => Ok(i),
+    }
+}
+
+#[test]
+fn test_iterjson() {
+    fn f(s: &str) -> Vec<String> {
+        IterJson::new(s.as_bytes())
+            .map(|s| String::from_utf8_lossy(s).to_string())
+            .collect()
+    }
+    assert_eq!(f(" { a { b { c } d { e } f {{ g }}   "), vec!["{ c }", "{ e }", "{ g }", "{{ g }}"]);
+    assert_eq!(f(r#"{"k":{"k":"v"}}"#), vec![r#"{"k":"v"}"#, r#"{"k":{"k":"v"}}"#]);
+    assert_eq!(f(r#"xxx}}xx{{xxx{a}"#), vec!["{a}"]);
+    let only_open = String::from_utf8(vec![b'{'; 1000000]).unwrap();
+    assert_eq!(f(&only_open), Vec::<String>::new());
+}
+
+#[test]
+fn test_alljson() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct S { x: u8 }
+    let actual: Vec<S> = all_json(&br#"{{  "x":1}{-}--{{{"x":2}}"#[..]).collect();
+    assert_eq!(actual, vec![S { x: 1 }, S { x: 2 }]);
+}

--- a/src/krpano/mod.rs
+++ b/src/krpano/mod.rs
@@ -42,8 +42,7 @@ impl From<KrpanoError> for DezoomerError {
 fn load_from_properties(url: &str, contents: &[u8])
                         -> Result<ZoomLevels, KrpanoError> {
     let image_properties: KrpanoMetadata = serde_xml_rs::from_reader(remove_bom(contents))?;
-    let slash_pos = url.rfind('/').unwrap_or(url.len() - 1);
-    let base_url = &Arc::new(format!("{}/", &url[0..slash_pos]));
+    let base_url = &Arc::new(url.to_string());
 
     Ok(image_properties.image.into_iter().flat_map(move |image| {
         let root_tile_size = image.tilesize.map(Vec2d::square);

--- a/src/krpano/mod.rs
+++ b/src/krpano/mod.rs
@@ -164,6 +164,6 @@ fn test_flat_multires() {
     assert_eq!(levels[1].size_hint(), Some(Vec2d { x: 3, y: 4 }));
     assert_eq!(format!("{:?}", levels[0]), "Krpano Flat");
     assert_eq!(levels[1].next_tiles(None), vec![
-        TileReference { url: "level=2 x=01 y=01".to_string(), position: Vec2d { x: 0, y: 0 } },
-        TileReference { url: "level=2 x=01 y=02".to_string(), position: Vec2d { x: 0, y: 3 } }]);
+        TileReference { url: "http://test.com/level=2%20x=01%20y=01".to_string(), position: Vec2d { x: 0, y: 0 } },
+        TileReference { url: "http://test.com/level=2%20x=01%20y=02".to_string(), position: Vec2d { x: 0, y: 3 } }]);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod pff;
 pub mod zoomify;
 pub mod krpano;
 pub mod iipimage;
+mod json_utils;
 
 fn stdin_line() -> Result<String, ZoomError> {
     let stdin = std::io::stdin();

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::iter::once;
+use std::path::PathBuf;
 
 use log::debug;
 use reqwest::{Client, header};
@@ -57,12 +58,16 @@ pub fn default_headers() -> HashMap<String, String> {
 }
 
 pub fn resolve_relative(base: &str, path: &str) -> String {
-    if let Ok(url) = Url::parse(base) {
+    if Url::parse(path).is_ok() {
+        return path.to_string()
+    } else if let Ok(url) = Url::parse(base) {
         if let Ok(r) = url.join(path) {
             return r.to_string()
         }
     }
-    base.rsplit('/').next().unwrap_or_default().to_string() + path
+    let mut res = PathBuf::from(base.rsplitn(2, '/').last().unwrap_or_default());
+    res.push(path);
+    res.to_string_lossy().to_string()
 }
 
 pub fn remove_bom(contents: &[u8]) -> &[u8] {
@@ -72,4 +77,15 @@ pub fn remove_bom(contents: &[u8]) -> &[u8] {
     if contents.starts_with(BOM) {
         &contents[BOM.len()..]
     } else { contents }
+}
+
+#[test]
+fn test_resolve_relative() {
+    assert_eq!(resolve_relative("/a/b", "c/d"), "/a/c/d");
+    assert_eq!(resolve_relative("C:\\X", "c/d"), "C:\\X/c/d");
+    assert_eq!(resolve_relative("/a/b", "http://example.com/x"), "http://example.com/x");
+    assert_eq!(resolve_relative("http://a.b", "http://example.com/x"), "http://example.com/x");
+    assert_eq!(resolve_relative("http://a.b", "c/d"), "http://a.b/c/d");
+    assert_eq!(resolve_relative("http://a.b/x", "c/d"), "http://a.b/c/d");
+    assert_eq!(resolve_relative("http://a.b/x/", "c/d"), "http://a.b/x/c/d");
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -81,8 +81,9 @@ pub fn remove_bom(contents: &[u8]) -> &[u8] {
 
 #[test]
 fn test_resolve_relative() {
-    assert_eq!(resolve_relative("/a/b", "c/d"), "/a/c/d");
-    assert_eq!(resolve_relative("C:\\X", "c/d"), "C:\\X/c/d");
+    use std::path::MAIN_SEPARATOR;
+    assert_eq!(resolve_relative("/a/b", "c/d"), format!("/a{}c/d", MAIN_SEPARATOR));
+    assert_eq!(resolve_relative("C:\\X", "c/d"), format!("C:\\X{}c/d", MAIN_SEPARATOR));
     assert_eq!(resolve_relative("/a/b", "http://example.com/x"), "http://example.com/x");
     assert_eq!(resolve_relative("http://a.b", "http://example.com/x"), "http://example.com/x");
     assert_eq!(resolve_relative("http://a.b", "c/d"), "http://a.b/c/d");


### PR DESCRIPTION
Normally when OpenSeadragon is called it is passed the location of a '.dzi' tile sources file located in remote file server.  This has the form:
```js
OpenSeadragon({
    id: 'img',
    prefixUrl: '/images/',
    tileSources: 'http://test.com/y/xy.dzi'
});
```

However, sometimes there is no '.dzi' file and the tile sources information is given directly within the page-source.  This then has the form:
```js
OpenSeadragon({
    id: 'img',
    prefixUrl: '/images/',
    tileSources: {
	Image: {
            type: 'image',
            xmlns: 'http://schemas.microsoft.com/deepzoom/2008',
	    Url: 'http://content.example.net/images/'
            Format:   'jpg', 
            Overlap:  '1', 
            TileSize: '254',
            Size: {
                Height: '4409',
                Width: '7793'
            }
	}
    }
});
```

With this second form a URL field is required so that OpenSeadragon knows where to locate the tiles.

This second form can be emulated by providing a link to a locally created '.dzi' file, such as:
```js
OpenSeadragon({
    id: 'img',
    prefixUrl: '/images/',
    tileSources: '/tmp/example.dzi'
});
```

However this local '.dzi' file needs to include a URL field, such as:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Image xmlns="http://schemas.microsoft.com/deepzoom/2009"
  Url="https://some/url/"
  Format="png"
  Overlap="1"
  TileSize="254"
  >
  <Size 
    Height="10000"
    Width="10000"
  />
</Image>
```

The proposed change allows the parsing of a 'Url' field, if present, in a '.dzi' file.  This field forms the base URL for tile requests and replaces the part up to and including '*_files' that would be present in a standard '.dzi' URL.

I would be grateful if you could tidy up the changes as I am sure that they can be made more elegant.

Many thanks!