### PR TITLE
Add support for filenames with dots in them

### DIFF
--- a/src/output_file.rs
+++ b/src/output_file.rs
@@ -37,7 +37,11 @@ pub fn get_outname(
             .map(|s| sanitize(s))
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| "dezoomified".into());
-        let mut path = base_dir.join(base).with_extension(extension);
+        let mut path = base_dir.to_path_buf();
+        let mut base_with_ext = OsString::from(&base);
+        base_with_ext.push(".");
+        base_with_ext.push(&extension);
+        path = path.join(base_with_ext);
 
         // append a suffix (_1,_2,..) to `outname` if  the file already exists
         let filename = path.file_stem().map(OsString::from).unwrap_or_default();


### PR DESCRIPTION
Previously, filenames in dots with them would have the part after the dot cut off:

```
St. Germain l'Auxerrois - Claude Monet
Image successfully saved to ... St.jpg
```

Now, the filename is correctly saved:

```
St. Germain l'Auxerrois - Claude Monet
Image successfully saved to ... St. Germain l'Auxerrois - Claude Monet.jpg
```

The only potential downside would be if a file extension already exists in `zoom_name`, in which case the result would be something like `image.jpg.jpg`. It seems to me that this should not happen, because I imagine `zoom_name` has the title of the image provided by the website, not a filename, but I have not tested this outside of GAP.