### PR TITLE
Add http1_title_case_headers support to reqwest http client

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -169,6 +169,7 @@ pub fn client<'a, I: Iterator<Item = (&'a String, &'a String)>>(
         header_map
     );
     let client = reqwest::Client::builder()
+        .http1_title_case_headers()
         .default_headers(header_map)
         .referer(false)
         .pool_max_idle_per_host(args.max_idle_per_host)


### PR DESCRIPTION
Some HTTP server implementations don't follow [HTTP 1.1 standard](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2):

> HTTP header fields, which include general-header (section [4.5](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.5)), request-header (section 5.3), response-header (section 6.2), and entity-header (section [7.1](https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.1)) fields, follow the same generic format as that given in Section [3.1](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.1) of RFC 822 [[9]](https://www.w3.org/Protocols/rfc2616/rfc2616-sec17.html#bib9). Each header field consists of a name followed by a colon (":") and the field value. Field names are **case-insensitive**.

Reqwest default behavior is lowercase headers, which might result in errors from some HTTP servers that don't follow HTTP 1.1 standard.
To avoid it, this PR uses the `http1_title_case_headers` function to add support for **case-sensitive** HTTP headers.