### PR TITLE
Add zif-tiff passthrough encoder and encoded-tile download pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,29 +226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,12 +355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,15 +432,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,16 +456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b536eebcabe54980476d120a182f7da2268fe02d22575cca99cee5fdda178280"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
 ]
 
 [[package]]
@@ -801,12 +753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +903,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,12 +925,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1066,10 +1021,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1079,11 +1032,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1261,6 +1212,22 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1560,55 +1527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,12 +1649,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1699,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1934,10 +1863,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "page_size"
@@ -2157,62 +2123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,19 +2296,18 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2433,21 +2342,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustdct"
@@ -2491,7 +2385,6 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2500,53 +2393,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2554,7 +2407,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2627,12 +2479,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2757,16 +2603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,12 +2610,6 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2961,21 +2791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,6 +2816,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3231,6 +3056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,15 +3168,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -3503,16 +3325,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3530,31 +3343,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3573,22 +3369,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3597,22 +3381,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3621,22 +3393,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3645,22 +3405,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "url",
+ "zif-tiff",
 ]
 
 [[package]]
@@ -3787,6 +3788,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zif-tiff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5492412367307b544ffff1321ef7261f7f707e726e6b47e72ff3c1069e3b7918"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,14 @@ log = "0.4"
 env_logger = "0.11"
 url = "2"
 fixedbitset = "0.5"
-reqwest = { version = "0.13", features = ["gzip", "zstd"] }
+reqwest = { version = "0.13", default-features = false, features = [
+    "charset",
+    "gzip",
+    "http2",
+    "native-tls",
+    "system-proxy",
+    "zstd",
+] }
 krpano-decrypt = "0.2"
 zif-tiff = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ url = "2"
 fixedbitset = "0.5"
 reqwest = { version = "0.13", features = ["gzip", "zstd"] }
 krpano-decrypt = "0.2"
+zif-tiff = "0.3.0"
 
 [dev-dependencies]
 criterion = "0.8"

--- a/src/auto.rs
+++ b/src/auto.rs
@@ -124,7 +124,7 @@ impl Dezoomer for AutoDezoomer {
                     false
                 }
                 Err(DezoomerError::NeedsData { uri }) => {
-                    debug!("dezoomer '{}' requested to load {}", dezoomer.name(), &uri);
+                    debug!("dezoomer '{}' requested to load {}", dezoomer.name(), uri);
                     if !self.needs_uris.contains(&uri) {
                         self.needs_uris.push(uri);
                     }
@@ -171,7 +171,7 @@ impl Dezoomer for AutoDezoomer {
                     return Ok(result);
                 }
                 Err(DezoomerError::NeedsData { uri }) => {
-                    debug!("dezoomer '{}' requested to load {}", dezoomer.name(), &uri);
+                    debug!("dezoomer '{}' requested to load {}", dezoomer.name(), uri);
                     if !self.needs_uris.contains(&uri) {
                         self.needs_uris.push(uri);
                     }

--- a/src/dezoomer.rs
+++ b/src/dezoomer.rs
@@ -355,6 +355,10 @@ pub trait TileProvider: Debug {
         None
     }
 
+    fn tile_size_hint(&self) -> Option<Vec2d> {
+        None
+    }
+
     /// A collection of http headers to use when requesting the tiles
     fn http_headers(&self) -> HashMap<String, String> {
         HashMap::new()
@@ -420,6 +424,9 @@ impl<'a> ZoomLevelIter<'a> {
     }
     pub fn size_hint(&self) -> Option<Vec2d> {
         self.zoom_level.size_hint()
+    }
+    pub fn tile_size_hint(&self) -> Option<Vec2d> {
+        self.zoom_level.tile_size_hint()
     }
 }
 
@@ -492,6 +499,10 @@ impl<T: TilesRect> TileProvider for T {
 
     fn tile_count_hint(&self) -> Option<u32> {
         Some(self.tile_count())
+    }
+
+    fn tile_size_hint(&self) -> Option<Vec2d> {
+        Some(self.tile_size())
     }
 
     fn http_headers(&self) -> HashMap<String, String> {

--- a/src/dezoomer.rs
+++ b/src/dezoomer.rs
@@ -204,6 +204,10 @@ impl TileProvider for TitledZoomLevel {
         self.inner.tile_count_hint()
     }
 
+    fn tile_size_hint(&self) -> Option<Vec2d> {
+        self.inner.tile_size_hint()
+    }
+
     fn http_headers(&self) -> HashMap<String, String> {
         self.inner.http_headers()
     }

--- a/src/dezoomer.rs
+++ b/src/dezoomer.rs
@@ -208,6 +208,10 @@ impl TileProvider for TitledZoomLevel {
         self.inner.tile_size_hint()
     }
 
+    fn scale_factor_hint(&self) -> Option<u32> {
+        self.inner.scale_factor_hint()
+    }
+
     fn has_overlapping_tiles(&self) -> bool {
         self.inner.has_overlapping_tiles()
     }
@@ -367,6 +371,10 @@ pub trait TileProvider: Debug {
         None
     }
 
+    fn scale_factor_hint(&self) -> Option<u32> {
+        None
+    }
+
     fn has_overlapping_tiles(&self) -> bool {
         false
     }
@@ -440,6 +448,9 @@ impl<'a> ZoomLevelIter<'a> {
     pub fn tile_size_hint(&self) -> Option<Vec2d> {
         self.zoom_level.tile_size_hint()
     }
+    pub fn scale_factor_hint(&self) -> Option<u32> {
+        self.zoom_level.scale_factor_hint()
+    }
     pub fn has_overlapping_tiles(&self) -> bool {
         self.zoom_level.has_overlapping_tiles()
     }
@@ -471,6 +482,10 @@ pub trait TilesRect: Debug {
 
     fn has_overlapping_tiles(&self) -> bool {
         false
+    }
+
+    fn scale_factor_hint(&self) -> Option<u32> {
+        None
     }
 
     fn tile_count(&self) -> u32 {
@@ -522,6 +537,10 @@ impl<T: TilesRect> TileProvider for T {
 
     fn tile_size_hint(&self) -> Option<Vec2d> {
         Some(self.tile_size())
+    }
+
+    fn scale_factor_hint(&self) -> Option<u32> {
+        TilesRect::scale_factor_hint(self)
     }
 
     fn has_overlapping_tiles(&self) -> bool {

--- a/src/dezoomer.rs
+++ b/src/dezoomer.rs
@@ -208,6 +208,10 @@ impl TileProvider for TitledZoomLevel {
         self.inner.tile_size_hint()
     }
 
+    fn has_overlapping_tiles(&self) -> bool {
+        self.inner.has_overlapping_tiles()
+    }
+
     fn http_headers(&self) -> HashMap<String, String> {
         self.inner.http_headers()
     }
@@ -363,6 +367,10 @@ pub trait TileProvider: Debug {
         None
     }
 
+    fn has_overlapping_tiles(&self) -> bool {
+        false
+    }
+
     /// A collection of http headers to use when requesting the tiles
     fn http_headers(&self) -> HashMap<String, String> {
         HashMap::new()
@@ -432,6 +440,9 @@ impl<'a> ZoomLevelIter<'a> {
     pub fn tile_size_hint(&self) -> Option<Vec2d> {
         self.zoom_level.tile_size_hint()
     }
+    pub fn has_overlapping_tiles(&self) -> bool {
+        self.zoom_level.has_overlapping_tiles()
+    }
 }
 
 /// Shortcut to return a single zoom level from a dezoomer
@@ -456,6 +467,10 @@ pub trait TilesRect: Debug {
     }
     fn post_process_fn(&self) -> PostProcessFn {
         PostProcessFn::None
+    }
+
+    fn has_overlapping_tiles(&self) -> bool {
+        false
     }
 
     fn tile_count(&self) -> u32 {
@@ -507,6 +522,10 @@ impl<T: TilesRect> TileProvider for T {
 
     fn tile_size_hint(&self) -> Option<Vec2d> {
         Some(self.tile_size())
+    }
+
+    fn has_overlapping_tiles(&self) -> bool {
+        TilesRect::has_overlapping_tiles(self)
     }
 
     fn http_headers(&self) -> HashMap<String, String> {

--- a/src/download_state.rs
+++ b/src/download_state.rs
@@ -275,10 +275,10 @@ async fn prepare_canvas_size(
     canvas: &mut TileBuffer,
     zoom_level_iter: &ZoomLevelIter<'_>,
 ) -> Result<(), ZoomError> {
-    if !canvas.has_size() {
-        if let Some(size) = zoom_level_iter.size_hint() {
-            canvas.set_size(size).await?;
-        }
+    if !canvas.has_size()
+        && let Some(size) = zoom_level_iter.size_hint()
+    {
+        canvas.set_size(size).await?;
     }
     Ok(())
 }

--- a/src/download_state.rs
+++ b/src/download_state.rs
@@ -4,7 +4,7 @@ use crate::dezoomer::{TileFetchResult, TileReference, ZoomLevel, ZoomLevelIter};
 use crate::encoder::tile_buffer::TileBuffer;
 use crate::errors::{self, ZoomError}; // `self` imports the errors module itself
 use crate::max_size_in_rect;
-use crate::network::{DownloadedTile, TileDownloader, client as network_client};
+use crate::network::{TileDownloader, client as network_client};
 use crate::throttler::Throttler;
 use crate::tile::{EncodedTile, Tile, load_encoded_tile, load_tile_with_metadata};
 use crate::vec2d::Vec2d; // This is a public function from lib.rs
@@ -189,19 +189,27 @@ impl<'a> TileDownloadCoordinator<'a> {
         zoom_level_iter: &ZoomLevelIter<'_>,
     ) -> Result<(), ZoomError> {
         let mut stream = futures::stream::iter(tile_refs)
-            .map(|tile_ref: TileReference| self.downloader.download_tile(tile_ref))
+            .map(|tile_ref: TileReference| {
+                self.downloader
+                    .download_tile_and_then(tile_ref, |downloaded| async move {
+                        tokio::task::spawn_blocking(move || {
+                            load_tile_with_metadata(downloaded.position, &downloaded.bytes)
+                        })
+                        .await?
+                        .map_err(ZoomError::from)
+                    })
+            })
             .buffer_unordered(self.args.parallelism);
 
         while let Some(tile_result) = stream.next().await {
             debug!("Received tile result: {:?}", tile_result);
             progress.increment();
 
-            let (tile, success) = process_downloaded_tile_result(
+            let (tile, success) = process_decoded_tile_result(
                 tile_result,
                 &mut state.tile_size,
                 zoom_level_iter.size_hint(),
-            )
-            .await?;
+            );
 
             progress.update_for_tile(&tile, success);
 
@@ -228,7 +236,16 @@ impl<'a> TileDownloadCoordinator<'a> {
         progress: &ProgressManager,
     ) -> Result<(), ZoomError> {
         let mut stream = futures::stream::iter(tile_refs)
-            .map(|tile_ref: TileReference| self.downloader.download_tile(tile_ref))
+            .map(|tile_ref: TileReference| {
+                self.downloader
+                    .download_tile_and_then(tile_ref, |downloaded| async move {
+                        tokio::task::spawn_blocking(move || {
+                            load_encoded_tile(downloaded.position, downloaded.bytes)
+                        })
+                        .await?
+                        .map_err(ZoomError::from)
+                    })
+            })
             .buffer_unordered(self.args.parallelism);
 
         while let Some(tile_result) = stream.next().await {
@@ -284,30 +301,20 @@ async fn prepare_canvas_size(
 }
 
 // Helper function, private to this module
-async fn process_downloaded_tile_result(
-    tile_result: Result<DownloadedTile, errors::TileDownloadError>,
+fn process_decoded_tile_result(
+    tile_result: Result<Tile, errors::TileDownloadError>,
     tile_size: &mut Option<Vec2d>,
     canvas_size: Option<Vec2d>,
-) -> Result<(Option<Tile>, bool), ZoomError> {
+) -> (Option<Tile>, bool) {
     match tile_result {
-        Ok(downloaded) => {
-            let position = downloaded.position;
-            let tile = tokio::task::spawn_blocking(move || {
-                load_tile_with_metadata(downloaded.position, &downloaded.bytes)
-            })
-            .await?;
-            match tile {
-                Ok(tile) => {
-                    *tile_size = Some(tile.size());
-                    Ok((Some(tile), true))
-                }
-                Err(_) => Ok((empty_tile_for(position, *tile_size, canvas_size), false)),
-            }
+        Ok(tile) => {
+            *tile_size = Some(tile.size());
+            (Some(tile), true)
         }
-        Err(err) => Ok((
+        Err(err) => (
             empty_tile_for(err.tile_reference.position, *tile_size, canvas_size),
             false,
-        )),
+        ),
     }
 }
 
@@ -326,58 +333,31 @@ fn empty_tile_for(
 }
 
 async fn process_encoded_tile_result(
-    tile_result: Result<DownloadedTile, errors::TileDownloadError>,
+    tile_result: Result<EncodedTile, errors::TileDownloadError>,
 ) -> Result<(Option<EncodedTile>, bool), ZoomError> {
     match tile_result {
-        Ok(downloaded) => {
-            let tile = tokio::task::spawn_blocking(move || {
-                load_encoded_tile(downloaded.position, downloaded.bytes)
-            })
-            .await?;
-            match tile {
-                Ok(tile) => Ok((Some(tile), true)),
-                Err(_) => Ok((None, false)),
-            }
-        }
+        Ok(tile) => Ok((Some(tile), true)),
         Err(_) => Ok((None, false)),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use image::ImageEncoder;
-
-    use super::process_downloaded_tile_result;
+    use super::process_decoded_tile_result;
     use crate::dezoomer::TileReference;
     use crate::errors::{TileDownloadError, ZoomError};
     use crate::max_size_in_rect;
-    use crate::network::DownloadedTile;
+    use crate::tile::Tile;
     use crate::vec2d::Vec2d;
 
-    #[tokio::test]
-    async fn test_process_downloaded_tile_result() {
+    #[test]
+    fn test_process_decoded_tile_result() {
         let mut tile_size: Option<Vec2d> = None;
         let canvas_size = Vec2d { x: 1000, y: 1000 };
 
-        let mut encoded_png = Vec::new();
-        image::codecs::png::PngEncoder::new(&mut encoded_png)
-            .write_image(
-                &vec![255; 256 * 256 * 3],
-                256,
-                256,
-                image::ExtendedColorType::Rgb8,
-            )
-            .unwrap();
-        let ok_result = Ok(DownloadedTile {
-            position: Vec2d { x: 0, y: 0 },
-            bytes: Arc::new(encoded_png),
-        });
+        let ok_result = Ok(Tile::empty(Vec2d { x: 0, y: 0 }, Vec2d { x: 256, y: 256 }));
         let (result_tile_opt, success) =
-            process_downloaded_tile_result(ok_result, &mut tile_size, Some(canvas_size))
-                .await
-                .unwrap();
+            process_decoded_tile_result(ok_result, &mut tile_size, Some(canvas_size));
 
         assert!(success, "Tile processing should succeed for Ok result");
         assert!(
@@ -409,9 +389,7 @@ mod tests {
         };
         let err_result = Err(error);
         let (result_tile_opt_err, success_err) =
-            process_downloaded_tile_result(err_result, &mut tile_size, Some(canvas_size))
-                .await
-                .unwrap();
+            process_decoded_tile_result(err_result, &mut tile_size, Some(canvas_size));
 
         assert!(!success_err, "Tile processing should fail for Err result");
         assert!(

--- a/src/download_state.rs
+++ b/src/download_state.rs
@@ -291,24 +291,37 @@ async fn process_downloaded_tile_result(
 ) -> Result<(Option<Tile>, bool), ZoomError> {
     match tile_result {
         Ok(downloaded) => {
+            let position = downloaded.position;
             let tile = tokio::task::spawn_blocking(move || {
                 load_tile_with_metadata(downloaded.position, &downloaded.bytes)
             })
-            .await??;
-            *tile_size = Some(tile.size());
-            Ok((Some(tile), true))
-        }
-        Err(err) => {
-            let position = err.tile_reference.position;
-            let empty_tile = match (*tile_size, canvas_size) {
-                (Some(current_tile_size), Some(current_canvas_size)) => {
-                    let size = max_size_in_rect(position, current_tile_size, current_canvas_size);
-                    Some(Tile::empty(position, size))
+            .await?;
+            match tile {
+                Ok(tile) => {
+                    *tile_size = Some(tile.size());
+                    Ok((Some(tile), true))
                 }
-                _ => None,
-            };
-            Ok((empty_tile, false))
+                Err(_) => Ok((empty_tile_for(position, *tile_size, canvas_size), false)),
+            }
         }
+        Err(err) => Ok((
+            empty_tile_for(err.tile_reference.position, *tile_size, canvas_size),
+            false,
+        )),
+    }
+}
+
+fn empty_tile_for(
+    position: Vec2d,
+    tile_size: Option<Vec2d>,
+    canvas_size: Option<Vec2d>,
+) -> Option<Tile> {
+    match (tile_size, canvas_size) {
+        (Some(current_tile_size), Some(current_canvas_size)) => {
+            let size = max_size_in_rect(position, current_tile_size, current_canvas_size);
+            Some(Tile::empty(position, size))
+        }
+        _ => None,
     }
 }
 
@@ -320,8 +333,11 @@ async fn process_encoded_tile_result(
             let tile = tokio::task::spawn_blocking(move || {
                 load_encoded_tile(downloaded.position, downloaded.bytes)
             })
-            .await??;
-            Ok((Some(tile), true))
+            .await?;
+            match tile {
+                Ok(tile) => Ok((Some(tile), true)),
+                Err(_) => Ok((None, false)),
+            }
         }
         Err(_) => Ok((None, false)),
     }

--- a/src/download_state.rs
+++ b/src/download_state.rs
@@ -4,9 +4,9 @@ use crate::dezoomer::{TileFetchResult, TileReference, ZoomLevel, ZoomLevelIter};
 use crate::encoder::tile_buffer::TileBuffer;
 use crate::errors::{self, ZoomError}; // `self` imports the errors module itself
 use crate::max_size_in_rect;
-use crate::network::{TileDownloader, client as network_client};
+use crate::network::{DownloadedTile, TileDownloader, client as network_client};
 use crate::throttler::Throttler;
-use crate::tile::{EncodedTile, Tile};
+use crate::tile::{EncodedTile, Tile, load_encoded_tile, load_tile_with_metadata};
 use crate::vec2d::Vec2d; // This is a public function from lib.rs
 
 use futures::stream::StreamExt;
@@ -196,11 +196,12 @@ impl<'a> TileDownloadCoordinator<'a> {
             debug!("Received tile result: {:?}", tile_result);
             progress.increment();
 
-            let (tile, success) = process_tile_result(
+            let (tile, success) = process_downloaded_tile_result(
                 tile_result,
                 &mut state.tile_size,
                 zoom_level_iter.size_hint(),
-            );
+            )
+            .await?;
 
             progress.update_for_tile(&tile, success);
 
@@ -227,17 +228,14 @@ impl<'a> TileDownloadCoordinator<'a> {
         progress: &ProgressManager,
     ) -> Result<(), ZoomError> {
         let mut stream = futures::stream::iter(tile_refs)
-            .map(|tile_ref: TileReference| self.downloader.download_encoded_tile(tile_ref))
+            .map(|tile_ref: TileReference| self.downloader.download_tile(tile_ref))
             .buffer_unordered(self.args.parallelism);
 
         while let Some(tile_result) = stream.next().await {
             debug!("Received encoded tile result: {:?}", tile_result);
             progress.increment();
 
-            let (tile, success) = match tile_result {
-                Ok(tile) => (Some(tile), true),
-                Err(_) => (None, false),
-            };
+            let (tile, success) = process_encoded_tile_result(tile_result).await?;
 
             progress.update_for_encoded_tile(&tile, success);
 
@@ -284,50 +282,84 @@ async fn prepare_canvas_size(
 }
 
 // Helper function, private to this module
-fn process_tile_result(
-    tile_result: Result<Tile, errors::TileDownloadError>,
+async fn process_downloaded_tile_result(
+    tile_result: Result<DownloadedTile, errors::TileDownloadError>,
     tile_size: &mut Option<Vec2d>,
     canvas_size: Option<Vec2d>,
-) -> (Option<Tile>, bool) {
+) -> Result<(Option<Tile>, bool), ZoomError> {
     match tile_result {
-        Ok(tile) => {
-            *tile_size = Some(tile.size()); // Update tile_size with the size of the successfully downloaded tile
-            (Some(tile), true)
+        Ok(downloaded) => {
+            let tile = tokio::task::spawn_blocking(move || {
+                load_tile_with_metadata(downloaded.position, &downloaded.bytes)
+            })
+            .await??;
+            *tile_size = Some(tile.size());
+            Ok((Some(tile), true))
         }
         Err(err) => {
             let position = err.tile_reference.position;
-            // Try to create an empty tile only if we know the expected tile_size and canvas_size
             let empty_tile = match (*tile_size, canvas_size) {
                 (Some(current_tile_size), Some(current_canvas_size)) => {
                     let size = max_size_in_rect(position, current_tile_size, current_canvas_size);
                     Some(Tile::empty(position, size))
                 }
-                _ => None, // Not enough info to create a correctly sized empty tile
+                _ => None,
             };
-            (empty_tile, false)
+            Ok((empty_tile, false))
         }
+    }
+}
+
+async fn process_encoded_tile_result(
+    tile_result: Result<DownloadedTile, errors::TileDownloadError>,
+) -> Result<(Option<EncodedTile>, bool), ZoomError> {
+    match tile_result {
+        Ok(downloaded) => {
+            let tile = tokio::task::spawn_blocking(move || {
+                load_encoded_tile(downloaded.position, downloaded.bytes)
+            })
+            .await??;
+            Ok((Some(tile), true))
+        }
+        Err(_) => Ok((None, false)),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::process_tile_result; // From the parent module 'download_state'
+    use std::sync::Arc;
+
+    use image::ImageEncoder;
+
+    use super::process_downloaded_tile_result;
     use crate::dezoomer::TileReference;
     use crate::errors::{TileDownloadError, ZoomError};
     use crate::max_size_in_rect;
-    use crate::tile::Tile;
-    use crate::vec2d::Vec2d; // Used by process_tile_result, ensure it's in scope for understanding test logic
+    use crate::network::DownloadedTile;
+    use crate::vec2d::Vec2d;
 
-    #[test]
-    fn test_process_tile_result() {
+    #[tokio::test]
+    async fn test_process_downloaded_tile_result() {
         let mut tile_size: Option<Vec2d> = None;
         let canvas_size = Vec2d { x: 1000, y: 1000 };
 
-        // Test successful tile result
-        let tile_to_test = Tile::empty(Vec2d { x: 0, y: 0 }, Vec2d { x: 256, y: 256 });
-        let ok_result: Result<Tile, TileDownloadError> = Ok(tile_to_test.clone());
+        let mut encoded_png = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut encoded_png)
+            .write_image(
+                &vec![255; 256 * 256 * 3],
+                256,
+                256,
+                image::ExtendedColorType::Rgb8,
+            )
+            .unwrap();
+        let ok_result = Ok(DownloadedTile {
+            position: Vec2d { x: 0, y: 0 },
+            bytes: Arc::new(encoded_png),
+        });
         let (result_tile_opt, success) =
-            process_tile_result(ok_result, &mut tile_size, Some(canvas_size));
+            process_downloaded_tile_result(ok_result, &mut tile_size, Some(canvas_size))
+                .await
+                .unwrap();
 
         assert!(success, "Tile processing should succeed for Ok result");
         assert!(
@@ -347,9 +379,6 @@ mod tests {
             "tile_size variable mismatch after success"
         );
 
-        // Test failed tile result
-        // process_tile_result will use the current value of tile_size (if Some) to determine the size of the empty tile.
-        // So, we set it to what a previously successful tile might have set.
         tile_size = Some(Vec2d { x: 256, y: 256 });
 
         let tile_ref = TileReference {
@@ -357,12 +386,14 @@ mod tests {
             position: Vec2d { x: 100, y: 100 },
         };
         let error = TileDownloadError {
-            tile_reference: tile_ref.clone(), // Clone if tile_ref is used later, or ensure it's not.
-            cause: ZoomError::NoLevels,       // Using an arbitrary ZoomError variant
+            tile_reference: tile_ref.clone(),
+            cause: ZoomError::NoLevels,
         };
-        let err_result: Result<Tile, TileDownloadError> = Err(error);
+        let err_result = Err(error);
         let (result_tile_opt_err, success_err) =
-            process_tile_result(err_result, &mut tile_size, Some(canvas_size));
+            process_downloaded_tile_result(err_result, &mut tile_size, Some(canvas_size))
+                .await
+                .unwrap();
 
         assert!(!success_err, "Tile processing should fail for Err result");
         assert!(
@@ -370,9 +401,6 @@ mod tests {
             "Result tile should be Some (empty tile) for Err result"
         );
         if let Some(ref empty_tile) = result_tile_opt_err {
-            // The empty tile's size is determined by max_size_in_rect.
-            // Given position (100,100), tile_size (256,256), canvas_size (1000,1000),
-            // max_size_in_rect should return (256,256) as it fits.
             let expected_empty_size =
                 max_size_in_rect(tile_ref.position, tile_size.unwrap(), canvas_size);
             assert_eq!(
@@ -386,7 +414,6 @@ mod tests {
                 "Empty tile position mismatch"
             );
         }
-        // tile_size should remain Some(Vec2d { x: 256, y: 256 }) as per logic in process_tile_result for Err case.
         assert_eq!(
             tile_size,
             Some(Vec2d { x: 256, y: 256 }),

--- a/src/download_state.rs
+++ b/src/download_state.rs
@@ -6,7 +6,7 @@ use crate::errors::{self, ZoomError}; // `self` imports the errors module itself
 use crate::max_size_in_rect;
 use crate::network::{TileDownloader, client as network_client};
 use crate::throttler::Throttler;
-use crate::tile::Tile;
+use crate::tile::{EncodedTile, Tile};
 use crate::vec2d::Vec2d; // This is a public function from lib.rs
 
 use futures::stream::StreamExt;
@@ -110,6 +110,17 @@ impl ProgressManager {
         }
     }
 
+    pub(crate) fn update_for_encoded_tile(&self, tile: &Option<EncodedTile>, success: bool) {
+        if success {
+            if let Some(tile) = tile {
+                self.progress
+                    .set_message(format!("Loaded encoded tile at {}", tile.position));
+            }
+        } else {
+            self.progress.set_message("Failed to load encoded tile");
+        }
+    }
+
     pub(crate) fn finish(&self) {
         self.progress.finish_with_message("Finished tile download");
     }
@@ -161,12 +172,28 @@ impl<'a> TileDownloadCoordinator<'a> {
 
         prepare_canvas_size(canvas, zoom_level_iter).await?;
 
+        if canvas.prefers_encoded_tiles() {
+            self.download_encoded_batch(tile_refs, canvas, state, progress)
+                .await
+        } else {
+            self.download_decoded_batch(tile_refs, canvas, state, progress, zoom_level_iter)
+                .await
+        }
+    }
+    async fn download_decoded_batch(
+        &mut self,
+        tile_refs: Vec<TileReference>,
+        canvas: &mut TileBuffer,
+        state: &mut DownloadState,
+        progress: &ProgressManager,
+        zoom_level_iter: &ZoomLevelIter<'_>,
+    ) -> Result<(), ZoomError> {
         let mut stream = futures::stream::iter(tile_refs)
             .map(|tile_ref: TileReference| self.downloader.download_tile(tile_ref))
             .buffer_unordered(self.args.parallelism);
 
         while let Some(tile_result) = stream.next().await {
-            debug!("Received tile result: {:?}", tile_result); // Tile and TileDownloadError need Debug
+            debug!("Received tile result: {:?}", tile_result);
             progress.increment();
 
             let (tile, success) = process_tile_result(
@@ -186,6 +213,43 @@ impl<'a> TileDownloadCoordinator<'a> {
 
             if let Some(tile) = tile {
                 canvas.add_tile(tile).await;
+            }
+            self.throttler.wait().await;
+        }
+        Ok(())
+    }
+
+    async fn download_encoded_batch(
+        &mut self,
+        tile_refs: Vec<TileReference>,
+        canvas: &mut TileBuffer,
+        state: &mut DownloadState,
+        progress: &ProgressManager,
+    ) -> Result<(), ZoomError> {
+        let mut stream = futures::stream::iter(tile_refs)
+            .map(|tile_ref: TileReference| self.downloader.download_encoded_tile(tile_ref))
+            .buffer_unordered(self.args.parallelism);
+
+        while let Some(tile_result) = stream.next().await {
+            debug!("Received encoded tile result: {:?}", tile_result);
+            progress.increment();
+
+            let (tile, success) = match tile_result {
+                Ok(tile) => (Some(tile), true),
+                Err(_) => (None, false),
+            };
+
+            progress.update_for_encoded_tile(&tile, success);
+
+            if success {
+                state.record_success();
+                if let Some(ref tile) = tile {
+                    state.set_tile_size(tile.size);
+                }
+            }
+
+            if let Some(tile) = tile {
+                canvas.add_encoded_tile(tile).await;
             }
             self.throttler.wait().await;
         }

--- a/src/download_state.rs
+++ b/src/download_state.rs
@@ -275,8 +275,10 @@ async fn prepare_canvas_size(
     canvas: &mut TileBuffer,
     zoom_level_iter: &ZoomLevelIter<'_>,
 ) -> Result<(), ZoomError> {
-    if let Some(size) = zoom_level_iter.size_hint() {
-        canvas.set_size(size).await?;
+    if !canvas.has_size() {
+        if let Some(size) = zoom_level_iter.size_hint() {
+            canvas.set_size(size).await?;
+        }
     }
     Ok(())
 }

--- a/src/dzi/dzi_file.rs
+++ b/src/dzi/dzi_file.rs
@@ -2,9 +2,9 @@ use std::fmt::Debug;
 
 use serde::Deserialize;
 
+use crate::Vec2d;
 use crate::json_utils::number_or_string;
 use crate::network::resolve_relative;
-use crate::Vec2d;
 use url::Url;
 
 use super::DziError;

--- a/src/dzi/mod.rs
+++ b/src/dzi/mod.rs
@@ -142,6 +142,10 @@ impl TilesRect for DziLevel {
         let name = suffix.trim_end_matches("_files");
         Some(name.to_string())
     }
+
+    fn has_overlapping_tiles(&self) -> bool {
+        self.overlap > 0
+    }
 }
 
 impl std::fmt::Debug for DziLevel {

--- a/src/encoder/iiif_encoder.rs
+++ b/src/encoder/iiif_encoder.rs
@@ -135,9 +135,21 @@ struct IIIFTileSaver {
 
 impl IIIFTileSaver {
     fn save_tile_at_scale(&self, scale_factor: u32, tile: Tile) -> io::Result<()> {
-        let tile_size = tile.size();
-        let full_position = tile.position * scale_factor;
-        let full_size = tile.size() * scale_factor;
+        self.save_tile_region(
+            tile.position * scale_factor,
+            tile.size() * scale_factor,
+            tile.size(),
+            tile,
+        )
+    }
+
+    fn save_tile_region(
+        &self,
+        full_position: Vec2d,
+        full_size: Vec2d,
+        tile_size: Vec2d,
+        tile: Tile,
+    ) -> io::Result<()> {
         let region = format!(
             "{},{},{},{}",
             full_position.x, full_position.y, full_size.x, full_size.y
@@ -161,7 +173,7 @@ impl IIIFTileSaver {
 }
 
 impl TileSaver for IIIFTileSaver {
-    fn save_tile(&self, _size: Vec2d, tile: Tile) -> io::Result<()> {
-        self.save_tile_at_scale(1, tile)
+    fn save_tile(&self, size: Vec2d, tile: Tile) -> io::Result<()> {
+        self.save_tile_region(tile.position, size, tile.size(), tile)
     }
 }

--- a/src/encoder/iiif_encoder.rs
+++ b/src/encoder/iiif_encoder.rs
@@ -14,11 +14,14 @@ use crate::iiif::tile_info;
 use crate::tile::Tile;
 use crate::{Vec2d, ZoomError};
 
-use super::Encoder;
+use super::{Encoder, SourceLevel};
 
 pub struct IiifEncoder {
     retiler: Retiler<IIIFTileSaver>,
     root_path: PathBuf,
+    direct_tile_saver: Arc<IIIFTileSaver>,
+    direct_levels: Vec<SourceLevel>,
+    current_level: Option<SourceLevel>,
 }
 
 impl IiifEncoder {
@@ -26,28 +29,51 @@ impl IiifEncoder {
         let _ = std::fs::remove_file(&destination);
         debug!("Creating IIIF  directory at {:?}", &destination);
         std::fs::create_dir(&destination)?;
-        let tile_saver = IIIFTileSaver {
+        let tile_saver = Arc::new(IIIFTileSaver {
             root_path: destination.clone(),
             quality,
-        };
+        });
         let tile_size = Vec2d::square(512);
         Ok(IiifEncoder {
-            retiler: Retiler::new(size, tile_size, Arc::new(tile_saver), 1),
+            retiler: Retiler::new(size, tile_size, Arc::clone(&tile_saver), 1),
             root_path: destination,
+            direct_tile_saver: tile_saver,
+            direct_levels: Vec::new(),
+            current_level: None,
         })
     }
 }
 
 impl Encoder for IiifEncoder {
+    fn begin_level(&mut self, level: SourceLevel) -> io::Result<()> {
+        self.current_level = Some(level);
+        self.direct_levels.push(level);
+        Ok(())
+    }
+
     fn add_tile(&mut self, tile: Tile) -> io::Result<()> {
-        self.retiler.add_tile(&tile)
+        if let Some(level) = self.current_level {
+            self.direct_tile_saver
+                .save_tile_at_scale(level.scale_factor, tile)
+        } else {
+            self.retiler.add_tile(&tile)
+        }
     }
 
     fn finalize(&mut self) -> io::Result<()> {
-        self.retiler.finalize();
-        let scale_factors = (0..self.retiler.level_count())
-            .map(|n| 2u32.pow(n))
-            .collect::<Vec<_>>();
+        if self.direct_levels.is_empty() {
+            self.retiler.finalize();
+        }
+        let scale_factors = if self.direct_levels.is_empty() {
+            (0..self.retiler.level_count())
+                .map(|n| 2u32.pow(n))
+                .collect::<Vec<_>>()
+        } else {
+            self.direct_levels
+                .iter()
+                .map(|level| level.scale_factor)
+                .collect::<Vec<_>>()
+        };
         let tile_size = self.retiler.tile_size;
         let image_info = tile_info::ImageInfo {
             context: Some("http://iiif.io/api/image/3/context.json".to_string()),
@@ -103,12 +129,14 @@ struct IIIFTileSaver {
     quality: u8,
 }
 
-impl TileSaver for IIIFTileSaver {
-    fn save_tile(&self, size: Vec2d, tile: Tile) -> io::Result<()> {
+impl IIIFTileSaver {
+    fn save_tile_at_scale(&self, scale_factor: u32, tile: Tile) -> io::Result<()> {
         let tile_size = tile.size();
+        let full_position = tile.position * scale_factor;
+        let full_size = tile.size() * scale_factor;
         let region = format!(
             "{},{},{},{}",
-            tile.position.x, tile.position.y, size.x, size.y
+            full_position.x, full_position.y, full_size.x, full_size.y
         );
         let tile_size_str = format!("{},{}", tile_size.x, tile_size.y);
         let rotation = "0";
@@ -125,5 +153,11 @@ impl TileSaver for IIIFTileSaver {
         tile.image
             .write_with_encoder(jpeg_writer)
             .map_err(image_error_to_io_error)
+    }
+}
+
+impl TileSaver for IIIFTileSaver {
+    fn save_tile(&self, _size: Vec2d, tile: Tile) -> io::Result<()> {
+        self.save_tile_at_scale(1, tile)
     }
 }

--- a/src/encoder/iiif_encoder.rs
+++ b/src/encoder/iiif_encoder.rs
@@ -27,7 +27,7 @@ pub struct IiifEncoder {
 impl IiifEncoder {
     pub fn new(destination: PathBuf, size: Vec2d, quality: u8) -> Result<Self, ZoomError> {
         let _ = std::fs::remove_file(&destination);
-        debug!("Creating IIIF  directory at {:?}", &destination);
+        debug!("Creating IIIF  directory at {:?}", destination);
         std::fs::create_dir(&destination)?;
         let tile_saver = Arc::new(IIIFTileSaver {
             root_path: destination.clone(),

--- a/src/encoder/iiif_encoder.rs
+++ b/src/encoder/iiif_encoder.rs
@@ -74,7 +74,11 @@ impl Encoder for IiifEncoder {
                 .map(|level| level.scale_factor)
                 .collect::<Vec<_>>()
         };
-        let tile_size = self.retiler.tile_size;
+        let tile_size = self
+            .direct_levels
+            .iter()
+            .find_map(|level| level.tile_size)
+            .unwrap_or(self.retiler.tile_size);
         let image_info = tile_info::ImageInfo {
             context: Some("http://iiif.io/api/image/3/context.json".to_string()),
             iiif_type: Some("ImageService3".to_string()),

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -20,6 +20,7 @@ pub struct SourceLevel {
     pub size: Vec2d,
     pub scale_factor: u32,
     pub tile_size: Option<Vec2d>,
+    pub has_overlapping_tiles: bool,
 }
 
 pub trait Encoder: Send + 'static {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -19,6 +19,7 @@ pub struct SourceLevel {
     pub index: usize,
     pub size: Vec2d,
     pub scale_factor: u32,
+    pub tile_size: Option<Vec2d>,
 }
 
 pub trait Encoder: Send + 'static {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -68,7 +68,7 @@ fn encoder_for_name(
             size,
             quality,
         )?))
-    } else if extension == "tiff" || extension == "tif" {
+    } else if extension == "tiff" || extension == "tif" || extension == "zif" {
         debug!("Using the zif-tiff passthrough encoder");
         Ok(Box::new(zif_tiff_encoder::ZifTiffEncoder::new(
             destination,

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -14,7 +14,18 @@ mod retiler;
 pub mod tile_buffer;
 pub mod zif_tiff_encoder;
 
+#[derive(Clone, Copy, Debug)]
+pub struct SourceLevel {
+    pub index: usize,
+    pub size: Vec2d,
+    pub scale_factor: u32,
+}
+
 pub trait Encoder: Send + 'static {
+    /// Start writing a source pyramid level.
+    fn begin_level(&mut self, _level: SourceLevel) -> std::io::Result<()> {
+        Ok(())
+    }
     /// Add a tile to the image
     fn add_tile(&mut self, tile: Tile) -> std::io::Result<()>;
     /// Add an encoded tile to the image without decoding it.

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -84,7 +84,7 @@ fn encoder_for_name(
     } else {
         debug!(
             "Using the generic canvas implementation {}",
-            &destination.to_string_lossy()
+            destination.to_string_lossy()
         );
         Ok(Box::new(canvas::Canvas::<Rgba<u8>>::new_generic(
             destination,

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use image::{DynamicImage, GenericImageView, Rgb, Rgba, SubImage};
 use log::debug;
 
-use crate::tile::Tile;
+use crate::tile::{EncodedTile, Tile};
 use crate::{Vec2d, ZoomError, max_size_in_rect};
 
 pub mod canvas;
@@ -12,10 +12,21 @@ pub mod pixel_streamer;
 pub mod png_encoder;
 mod retiler;
 pub mod tile_buffer;
+pub mod zif_tiff_encoder;
 
 pub trait Encoder: Send + 'static {
     /// Add a tile to the image
     fn add_tile(&mut self, tile: Tile) -> std::io::Result<()>;
+    /// Add an encoded tile to the image without decoding it.
+    fn add_encoded_tile(&mut self, _tile: EncodedTile) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            format!(
+                "{} does not support encoded tile passthrough",
+                std::any::type_name::<Self>()
+            ),
+        ))
+    }
     /// To be called when no more tile will be added
     fn finalize(&mut self) -> std::io::Result<()>;
     /// Size of the image being encoded
@@ -43,6 +54,12 @@ fn encoder_for_name(
             destination,
             size,
             quality,
+        )?))
+    } else if extension == "tiff" || extension == "tif" {
+        debug!("Using the zif-tiff passthrough encoder");
+        Ok(Box::new(zif_tiff_encoder::ZifTiffEncoder::new(
+            destination,
+            size,
         )?))
     } else if extension == "jpeg" || extension == "jpg" {
         debug!("Using the jpeg encoder with a quality of {quality}");

--- a/src/encoder/retiler.rs
+++ b/src/encoder/retiler.rs
@@ -236,7 +236,7 @@ impl TmpTile {
         let tmp_tile_path = Self::path(self_position, scale_factor);
         debug!(
             "Opening partial tile of size {} at {:?} in order to paste pixels from {} to {}",
-            scaled_size, &tmp_tile_path, top_left, bottom_right
+            scaled_size, tmp_tile_path, top_left, bottom_right
         );
         let mut tile_img = image::open(&tmp_tile_path)
             .unwrap_or_else(|_| image::DynamicImage::new_rgb8(scaled_size.x, scaled_size.y));
@@ -253,7 +253,7 @@ impl TmpTile {
             // The tile has been fully covered by pixels
             debug!(
                 "Removing completed tile of level {} at position {}: {:?}",
-                level_size, self_position, &tmp_tile_path
+                level_size, self_position, tmp_tile_path
             );
             let _ = std::fs::remove_file(&tmp_tile_path);
             Ok(Some(tile_img))

--- a/src/encoder/tile_buffer.rs
+++ b/src/encoder/tile_buffer.rs
@@ -92,7 +92,7 @@ impl TileBuffer {
     pub async fn begin_level(&mut self, level: SourceLevel) -> Result<(), ZoomError> {
         let prefer_encoded_tiles = {
             let extension = self.destination().extension().unwrap_or_default();
-            extension == "tiff" || extension == "tif"
+            extension == "tiff" || extension == "tif" || extension == "zif"
         };
         match self {
             TileBuffer::Buffering {

--- a/src/encoder/tile_buffer.rs
+++ b/src/encoder/tile_buffer.rs
@@ -7,7 +7,7 @@ use log::debug;
 use tokio::sync::mpsc;
 
 use crate::encoder::{Encoder, encoder_for_name};
-use crate::tile::Tile;
+use crate::tile::{EncodedTile, Tile};
 use crate::{Vec2d, ZoomError};
 use log::warn;
 
@@ -16,6 +16,7 @@ pub enum TileBuffer {
     Buffering {
         destination: PathBuf,
         buffer: Vec<Tile>,
+        encoded_buffer: Vec<EncodedTile>,
         compression: u8,
     },
     Writing {
@@ -33,6 +34,7 @@ impl TileBuffer {
         Ok(TileBuffer::Buffering {
             destination,
             buffer: vec![],
+            encoded_buffer: vec![],
             compression,
         })
     }
@@ -41,6 +43,7 @@ impl TileBuffer {
         let next_state = match self {
             TileBuffer::Buffering {
                 buffer,
+                encoded_buffer,
                 destination,
                 compression,
             } => {
@@ -51,6 +54,9 @@ impl TileBuffer {
                 for tile in buffer.drain(..) {
                     encoder.add_tile(tile)?;
                 }
+                for tile in encoded_buffer.drain(..) {
+                    encoder.add_encoded_tile(tile)?;
+                }
                 buffer_tiles(encoder, destination).await
             }
             TileBuffer::Writing { .. } => {
@@ -59,6 +65,11 @@ impl TileBuffer {
         };
         *self = next_state;
         Ok(())
+    }
+
+    pub fn prefers_encoded_tiles(&self) -> bool {
+        let extension = self.destination().extension().unwrap_or_default();
+        extension == "tiff" || extension == "tif"
     }
 
     /// Add a tile to the image
@@ -74,13 +85,36 @@ impl TileBuffer {
         }
     }
 
+    /// Add an encoded tile to the image without decoding it.
+    pub async fn add_encoded_tile(&mut self, tile: EncodedTile) {
+        match self {
+            TileBuffer::Buffering { encoded_buffer, .. } => encoded_buffer.push(tile),
+            TileBuffer::Writing { tile_sender, .. } => {
+                tile_sender
+                    .send(TileBufferMsg::AddEncodedTile(tile))
+                    .await
+                    .expect("The tile writer ended unexpectedly");
+            }
+        }
+    }
+
     /// To be called when no more tile will be added
     pub async fn finalize(&mut self) -> Result<(), ZoomError> {
-        if let TileBuffer::Buffering { buffer, .. } = self {
-            let size = buffer
+        if let TileBuffer::Buffering {
+            buffer,
+            encoded_buffer,
+            ..
+        } = self
+        {
+            let decoded_size = buffer
                 .iter()
                 .map(|t| t.position + t.size())
                 .fold(Vec2d { x: 0, y: 0 }, Vec2d::max);
+            let encoded_size = encoded_buffer
+                .iter()
+                .map(|t| t.position + t.size)
+                .fold(Vec2d { x: 0, y: 0 }, Vec2d::max);
+            let size = decoded_size.max(encoded_size);
             self.set_size(size).await?;
         }
         let (tile_sender, error_receiver) = match self {
@@ -112,6 +146,7 @@ impl TileBuffer {
 #[derive(Debug)]
 pub enum TileBufferMsg {
     AddTile(Tile),
+    AddEncodedTile(EncodedTile),
     Close,
 }
 
@@ -126,6 +161,14 @@ async fn buffer_tiles(mut encoder: Box<dyn Encoder>, destination: PathBuf) -> Ti
                     let result = tokio::task::block_in_place(|| encoder.add_tile(tile));
                     if let Err(err) = result {
                         warn!("Error when adding tile: {err}");
+                        error_sender.send(err).await.expect("could not send error");
+                    }
+                }
+                TileBufferMsg::AddEncodedTile(tile) => {
+                    debug!("Sending encoded tile to encoder: {tile:?}");
+                    let result = tokio::task::block_in_place(|| encoder.add_encoded_tile(tile));
+                    if let Err(err) = result {
+                        warn!("Error when adding encoded tile: {err}");
                         error_sender.send(err).await.expect("could not send error");
                     }
                 }

--- a/src/encoder/tile_buffer.rs
+++ b/src/encoder/tile_buffer.rs
@@ -18,11 +18,13 @@ pub enum TileBuffer {
         buffer: Vec<Tile>,
         encoded_buffer: Vec<EncodedTile>,
         compression: u8,
+        prefer_encoded_tiles: bool,
     },
     Writing {
         destination: PathBuf,
         tile_sender: mpsc::Sender<TileBufferMsg>,
-        error_receiver: mpsc::Receiver<std::io::Error>,
+        error_receiver: mpsc::UnboundedReceiver<std::io::Error>,
+        prefer_encoded_tiles: bool,
     },
 }
 
@@ -36,6 +38,7 @@ impl TileBuffer {
             buffer: vec![],
             encoded_buffer: vec![],
             compression,
+            prefer_encoded_tiles: false,
         })
     }
 
@@ -46,6 +49,7 @@ impl TileBuffer {
                 encoded_buffer,
                 destination,
                 compression,
+                prefer_encoded_tiles,
             } => {
                 let destination = std::mem::take(destination);
                 debug!("Creating a tile writer for an image of size {size}");
@@ -57,7 +61,7 @@ impl TileBuffer {
                 for tile in encoded_buffer.drain(..) {
                     encoder.add_encoded_tile(tile)?;
                 }
-                buffer_tiles(encoder, destination).await
+                buffer_tiles(encoder, destination, *prefer_encoded_tiles).await
             }
             TileBuffer::Writing { .. } => {
                 unreachable!("The size of the image can be set only once")
@@ -72,14 +76,30 @@ impl TileBuffer {
     }
 
     pub fn prefers_encoded_tiles(&self) -> bool {
-        let extension = self.destination().extension().unwrap_or_default();
-        extension == "tiff" || extension == "tif"
+        match self {
+            TileBuffer::Buffering {
+                prefer_encoded_tiles,
+                ..
+            }
+            | TileBuffer::Writing {
+                prefer_encoded_tiles,
+                ..
+            } => *prefer_encoded_tiles,
+        }
     }
 
     /// Start writing a source pyramid level.
     pub async fn begin_level(&mut self, level: SourceLevel) -> Result<(), ZoomError> {
+        let prefer_encoded_tiles = {
+            let extension = self.destination().extension().unwrap_or_default();
+            extension == "tiff" || extension == "tif"
+        };
         match self {
-            TileBuffer::Buffering { .. } => {
+            TileBuffer::Buffering {
+                prefer_encoded_tiles: current_preference,
+                ..
+            } => {
+                *current_preference = prefer_encoded_tiles;
                 self.set_size(level.size).await?;
                 if let TileBuffer::Writing { tile_sender, .. } = self {
                     tile_sender.send(TileBufferMsg::BeginLevel(level)).await?;
@@ -88,7 +108,12 @@ impl TileBuffer {
                     unreachable!("set_size transitions buffering to writing")
                 }
             }
-            TileBuffer::Writing { tile_sender, .. } => {
+            TileBuffer::Writing {
+                tile_sender,
+                prefer_encoded_tiles: current_preference,
+                ..
+            } => {
+                *current_preference = prefer_encoded_tiles;
                 tile_sender.send(TileBufferMsg::BeginLevel(level)).await?;
                 Ok(())
             }
@@ -174,9 +199,13 @@ pub enum TileBufferMsg {
     Close,
 }
 
-async fn buffer_tiles(mut encoder: Box<dyn Encoder>, destination: PathBuf) -> TileBuffer {
+async fn buffer_tiles(
+    mut encoder: Box<dyn Encoder>,
+    destination: PathBuf,
+    prefer_encoded_tiles: bool,
+) -> TileBuffer {
     let (tile_sender, mut tile_receiver) = mpsc::channel(1024);
-    let (error_sender, error_receiver) = mpsc::channel(1);
+    let (error_sender, error_receiver) = mpsc::unbounded_channel();
     tokio::spawn(async move {
         while let Some(msg) = tile_receiver.recv().await {
             match msg {
@@ -185,7 +214,7 @@ async fn buffer_tiles(mut encoder: Box<dyn Encoder>, destination: PathBuf) -> Ti
                     let result = tokio::task::block_in_place(|| encoder.begin_level(level));
                     if let Err(err) = result {
                         warn!("Error when starting output source level: {err}");
-                        error_sender.send(err).await.expect("could not send error");
+                        error_sender.send(err).expect("could not send error");
                     }
                 }
                 TileBufferMsg::AddTile(tile) => {
@@ -193,7 +222,7 @@ async fn buffer_tiles(mut encoder: Box<dyn Encoder>, destination: PathBuf) -> Ti
                     let result = tokio::task::block_in_place(|| encoder.add_tile(tile));
                     if let Err(err) = result {
                         warn!("Error when adding tile: {err}");
-                        error_sender.send(err).await.expect("could not send error");
+                        error_sender.send(err).expect("could not send error");
                     }
                 }
                 TileBufferMsg::AddEncodedTile(tile) => {
@@ -201,7 +230,7 @@ async fn buffer_tiles(mut encoder: Box<dyn Encoder>, destination: PathBuf) -> Ti
                     let result = tokio::task::block_in_place(|| encoder.add_encoded_tile(tile));
                     if let Err(err) = result {
                         warn!("Error when adding encoded tile: {err}");
-                        error_sender.send(err).await.expect("could not send error");
+                        error_sender.send(err).expect("could not send error");
                     }
                 }
                 TileBufferMsg::Close => {
@@ -212,12 +241,13 @@ async fn buffer_tiles(mut encoder: Box<dyn Encoder>, destination: PathBuf) -> Ti
         debug!("Finalizing the encoder");
         if let Err(err) = encoder.finalize() {
             warn!("Error when finalizing image: {err}");
-            error_sender.send(err).await.expect("could not send error");
+            error_sender.send(err).expect("could not send error");
         }
     });
     TileBuffer::Writing {
         tile_sender,
         error_receiver,
         destination,
+        prefer_encoded_tiles,
     }
 }

--- a/src/encoder/tile_buffer.rs
+++ b/src/encoder/tile_buffer.rs
@@ -67,6 +67,10 @@ impl TileBuffer {
         Ok(())
     }
 
+    pub fn has_size(&self) -> bool {
+        matches!(self, TileBuffer::Writing { .. })
+    }
+
     pub fn prefers_encoded_tiles(&self) -> bool {
         let extension = self.destination().extension().unwrap_or_default();
         extension == "tiff" || extension == "tif"

--- a/src/encoder/tile_buffer.rs
+++ b/src/encoder/tile_buffer.rs
@@ -6,7 +6,7 @@ Used to receive tiles asynchronously and provide them to the encoder
 use log::debug;
 use tokio::sync::mpsc;
 
-use crate::encoder::{Encoder, encoder_for_name};
+use crate::encoder::{Encoder, SourceLevel, encoder_for_name};
 use crate::tile::{EncodedTile, Tile};
 use crate::{Vec2d, ZoomError};
 use log::warn;
@@ -70,6 +70,25 @@ impl TileBuffer {
     pub fn prefers_encoded_tiles(&self) -> bool {
         let extension = self.destination().extension().unwrap_or_default();
         extension == "tiff" || extension == "tif"
+    }
+
+    /// Start writing a source pyramid level.
+    pub async fn begin_level(&mut self, level: SourceLevel) -> Result<(), ZoomError> {
+        match self {
+            TileBuffer::Buffering { .. } => {
+                self.set_size(level.size).await?;
+                if let TileBuffer::Writing { tile_sender, .. } = self {
+                    tile_sender.send(TileBufferMsg::BeginLevel(level)).await?;
+                    Ok(())
+                } else {
+                    unreachable!("set_size transitions buffering to writing")
+                }
+            }
+            TileBuffer::Writing { tile_sender, .. } => {
+                tile_sender.send(TileBufferMsg::BeginLevel(level)).await?;
+                Ok(())
+            }
+        }
     }
 
     /// Add a tile to the image
@@ -145,6 +164,7 @@ impl TileBuffer {
 
 #[derive(Debug)]
 pub enum TileBufferMsg {
+    BeginLevel(SourceLevel),
     AddTile(Tile),
     AddEncodedTile(EncodedTile),
     Close,
@@ -156,6 +176,14 @@ async fn buffer_tiles(mut encoder: Box<dyn Encoder>, destination: PathBuf) -> Ti
     tokio::spawn(async move {
         while let Some(msg) = tile_receiver.recv().await {
             match msg {
+                TileBufferMsg::BeginLevel(level) => {
+                    debug!("Starting output source level: {level:?}");
+                    let result = tokio::task::block_in_place(|| encoder.begin_level(level));
+                    if let Err(err) = result {
+                        warn!("Error when starting output source level: {err}");
+                        error_sender.send(err).await.expect("could not send error");
+                    }
+                }
                 TileBufferMsg::AddTile(tile) => {
                     debug!("Sending tile to encoder: {tile:?}");
                     let result = tokio::task::block_in_place(|| encoder.add_tile(tile));

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -17,6 +17,7 @@ pub struct ZifTiffEncoder {
     tile_size: Option<Vec2d>,
     codec: Option<Codec>,
     color: Option<(ColorModel, u16)>,
+    jpeg: Option<JpegTileInfo>,
     occupied_tiles: HashSet<(usize, u64, u64)>,
     size: Vec2d,
     destination: PathBuf,
@@ -47,6 +48,7 @@ impl ZifTiffEncoder {
             tile_size: None,
             codec: None,
             color: None,
+            jpeg: None,
             occupied_tiles: HashSet::new(),
             size,
             destination,
@@ -67,25 +69,42 @@ impl ZifTiffEncoder {
         let tile_size = self.declared_tile_size.unwrap_or(tile.size);
         let codec = codec_for_format(tile.format)?;
         let (mut color_model, channels) = color_from_encoded_tile(tile)?;
+        let jpeg = if codec == Codec::Jpeg {
+            Some(parse_jpeg_tile_info(&tile.bytes)?)
+        } else {
+            None
+        };
         if codec == Codec::Jpeg {
             color_model = ColorModel::YCbCr;
         }
+        let ycbcr_subsampling = jpeg.map(|info| info.subsampling);
         debug!(
-            "Using zif-tiff passthrough encoder: tile size {tile_size}, codec {codec:?}, color {color_model:?}/{channels} channels"
+            "Using zif-tiff passthrough encoder: tile size {tile_size}, codec {codec:?}, color {color_model:?}/{channels} channels, JPEG subsampling {ycbcr_subsampling:?}"
         );
-        self.writer = zif_tiff::Writer::new()
+        let mut builder = zif_tiff::Writer::new()
             .dimensions((u64::from(self.size.x), u64::from(self.size.y)))
             .tile_size((tile_size.x, tile_size.y))
             .map_err(to_io_error)?
             .codec(codec)
             .color_model(color_model)
             .channels(channels)
-            .map_err(to_io_error)?
-            .build()
             .map_err(to_io_error)?;
+        if let Some(subsampling) = ycbcr_subsampling {
+            builder = if subsampling == (1, 1) || subsampling == (2, 2) {
+                builder
+                    .ycbcr_subsampling(subsampling)
+                    .map_err(to_io_error)?
+            } else {
+                builder
+                    .preserve_nonstandard_ycbcr_subsampling(subsampling)
+                    .map_err(to_io_error)?
+            };
+        }
+        self.writer = builder.build().map_err(to_io_error)?;
         self.tile_size = Some(tile_size);
         self.codec = Some(codec);
         self.color = Some((color_model, channels));
+        self.jpeg = jpeg;
         Ok(())
     }
 
@@ -173,6 +192,11 @@ impl Encoder for ZifTiffEncoder {
         if codec == Codec::Jpeg {
             color_model = ColorModel::YCbCr;
         }
+        let jpeg = match parse_jpeg_tile_info(&tile.bytes) {
+            Ok(jpeg) => jpeg,
+            Err(err) if self.source_pyramid => return Err(err),
+            Err(_) => return self.decode_or_fall_back(tile),
+        };
         let color = (color_model, channels);
         self.configure_from_first_tile(&tile)?;
 
@@ -187,6 +211,12 @@ impl Encoder for ZifTiffEncoder {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "cannot mix tile color models in one zif TIFF",
+            ));
+        }
+        if Some(jpeg) != self.jpeg {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cannot mix JPEG sampling layouts in one zif TIFF",
             ));
         }
         if !tile.position.x.is_multiple_of(expected_size.x)
@@ -237,6 +267,96 @@ impl Encoder for ZifTiffEncoder {
     fn size(&self) -> Vec2d {
         self.size
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct JpegTileInfo {
+    subsampling: (u16, u16),
+}
+
+fn parse_jpeg_tile_info(bytes: &[u8]) -> io::Result<JpegTileInfo> {
+    if bytes.len() < 4 || bytes[0] != 0xff || bytes[1] != 0xd8 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid JPEG tile",
+        ));
+    }
+
+    let mut pos = 2;
+    while pos + 4 <= bytes.len() {
+        while pos < bytes.len() && bytes[pos] == 0xff {
+            pos += 1;
+        }
+        if pos >= bytes.len() {
+            break;
+        }
+        let marker = bytes[pos];
+        pos += 1;
+        if marker == 0xd9 || marker == 0xda {
+            break;
+        }
+        if marker == 0x01 || (0xd0..=0xd7).contains(&marker) {
+            continue;
+        }
+        if pos + 2 > bytes.len() {
+            break;
+        }
+        let len = usize::from(u16::from_be_bytes([bytes[pos], bytes[pos + 1]]));
+        if len < 2 || pos + len > bytes.len() {
+            break;
+        }
+        let segment = &bytes[pos + 2..pos + len];
+        match marker {
+            0xc0 => return parse_jpeg_start_of_frame(segment),
+            0xc2 => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "progressive JPEG tiles cannot be passed through to zif TIFF",
+                ));
+            }
+            _ => {}
+        }
+        pos += len;
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "JPEG tile has no supported start-of-frame marker",
+    ))
+}
+
+fn parse_jpeg_start_of_frame(segment: &[u8]) -> io::Result<JpegTileInfo> {
+    if segment.len() < 6 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "truncated JPEG start-of-frame segment",
+        ));
+    }
+    let components = usize::from(segment[5]);
+    if components == 0 || segment.len() < 6 + components * 3 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid JPEG component table",
+        ));
+    }
+
+    let mut max_h = 1u16;
+    let mut max_v = 1u16;
+    for component in segment[6..6 + components * 3].chunks_exact(3) {
+        let sampling = component[1];
+        max_h = max_h.max(u16::from(sampling >> 4));
+        max_v = max_v.max(u16::from(sampling & 0x0f));
+    }
+    if max_h == 0 || max_v == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid JPEG sampling factors",
+        ));
+    }
+
+    Ok(JpegTileInfo {
+        subsampling: (max_h, max_v),
+    })
 }
 
 fn decoded_fallback_destination(destination: &std::path::Path) -> PathBuf {
@@ -326,5 +446,58 @@ mod tests {
         let tile = image.level_tiles(0).unwrap().next().unwrap();
         let stored = reader.fetch(tile.range()).unwrap();
         assert_eq!(stored.bytes(), bytes.as_slice());
+    }
+
+    #[test]
+    fn parses_jpeg_subsampling_from_baseline_frame() {
+        let jpeg = minimal_jpeg_with_sof(0xc0, 0x11);
+        assert_eq!(
+            parse_jpeg_tile_info(&jpeg).unwrap(),
+            JpegTileInfo {
+                subsampling: (1, 1)
+            }
+        );
+
+        let jpeg = minimal_jpeg_with_sof(0xc0, 0x22);
+        assert_eq!(
+            parse_jpeg_tile_info(&jpeg).unwrap(),
+            JpegTileInfo {
+                subsampling: (2, 2)
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_progressive_jpeg_passthrough_metadata() {
+        let jpeg = minimal_jpeg_with_sof(0xc2, 0x22);
+        assert!(parse_jpeg_tile_info(&jpeg).is_err());
+    }
+
+    fn minimal_jpeg_with_sof(marker: u8, first_component_sampling: u8) -> Vec<u8> {
+        vec![
+            0xff,
+            0xd8,
+            0xff,
+            marker,
+            0x00,
+            0x11,
+            0x08,
+            0x00,
+            0x10,
+            0x00,
+            0x10,
+            0x03,
+            0x01,
+            first_component_sampling,
+            0x00,
+            0x02,
+            0x11,
+            0x00,
+            0x03,
+            0x11,
+            0x00,
+            0xff,
+            0xd9,
+        ]
     }
 }

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -23,6 +23,7 @@ pub struct ZifTiffEncoder {
     declared_tile_size: Option<Vec2d>,
     fallback: Option<Canvas<Rgba<u8>>>,
     force_decoded_fallback: bool,
+    wants_pyramid: bool,
     current_level: usize,
 }
 
@@ -51,6 +52,7 @@ impl ZifTiffEncoder {
             declared_tile_size: None,
             fallback: None,
             force_decoded_fallback: false,
+            wants_pyramid: false,
             current_level: 0,
         })
     }
@@ -69,17 +71,18 @@ impl ZifTiffEncoder {
         debug!(
             "Using zif-tiff passthrough encoder: tile size {tile_size}, codec {codec:?}, color {color_model:?}/{channels} channels"
         );
-        self.writer = zif_tiff::Writer::new()
+        let mut builder = zif_tiff::Writer::new()
             .dimensions((u64::from(self.size.x), u64::from(self.size.y)))
             .tile_size((tile_size.x, tile_size.y))
             .map_err(to_io_error)?
             .codec(codec)
             .color_model(color_model)
             .channels(channels)
-            .map_err(to_io_error)?
-            .pyramid()
-            .build()
             .map_err(to_io_error)?;
+        if self.wants_pyramid {
+            builder = builder.pyramid();
+        }
+        self.writer = builder.build().map_err(to_io_error)?;
         self.tile_size = Some(tile_size);
         self.codec = Some(codec);
         self.color = Some((color_model, channels));
@@ -89,6 +92,7 @@ impl ZifTiffEncoder {
 
 impl Encoder for ZifTiffEncoder {
     fn begin_level(&mut self, level: SourceLevel) -> io::Result<()> {
+        self.wants_pyramid = true;
         self.current_level = level.index;
         if let Some(tile_size) = level.tile_size {
             self.declared_tile_size = Some(tile_size);

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -224,10 +224,9 @@ impl Encoder for ZifTiffEncoder {
 fn codec_for_format(format: ImageFormat) -> io::Result<Codec> {
     match format {
         ImageFormat::Jpeg => Ok(Codec::Jpeg),
-        ImageFormat::Png => Ok(Codec::Png),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "zif TIFF passthrough supports only JPEG and PNG input tiles",
+            "zif TIFF passthrough supports only JPEG input tiles",
         )),
     }
 }
@@ -268,16 +267,16 @@ mod tests {
 
     #[test]
     fn writes_input_tile_bytes_without_reencoding() {
-        let mut encoded_png = Vec::new();
-        image::codecs::png::PngEncoder::new(&mut encoded_png)
+        let mut encoded = Vec::new();
+        image::codecs::jpeg::JpegEncoder::new_with_quality(&mut encoded, 95)
             .write_image(
-                &vec![255; 16 * 16 * 3],
+                &vec![128; 16 * 16 * 3],
                 16,
                 16,
                 image::ExtendedColorType::Rgb8,
             )
             .unwrap();
-        let bytes = Arc::new(encoded_png);
+        let bytes = Arc::new(encoded);
         let dir = tempfile::tempdir().unwrap();
         let destination = dir.path().join("passthrough.tiff");
         let mut encoder = ZifTiffEncoder::new(destination.clone(), Vec2d { x: 16, y: 16 }).unwrap();
@@ -286,7 +285,7 @@ mod tests {
             .add_encoded_tile(EncodedTile {
                 position: Vec2d { x: 0, y: 0 },
                 bytes: Arc::clone(&bytes),
-                format: ImageFormat::Png,
+                format: ImageFormat::Jpeg,
                 size: Vec2d { x: 16, y: 16 },
                 color_type: ColorType::Rgb8,
             })

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -128,7 +128,9 @@ impl Encoder for ZifTiffEncoder {
                 "cannot mix tile codecs in one zif TIFF",
             ));
         }
-        if tile.position.x % expected_size.x != 0 || tile.position.y % expected_size.y != 0 {
+        if !tile.position.x.is_multiple_of(expected_size.x)
+            || !tile.position.y.is_multiple_of(expected_size.y)
+        {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "tile positions must align to the zif TIFF tile grid",

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -23,6 +23,7 @@ pub struct ZifTiffEncoder {
     declared_tile_size: Option<Vec2d>,
     fallback: Option<Canvas<Rgba<u8>>>,
     force_decoded_fallback: bool,
+    source_pyramid: bool,
     current_level: usize,
 }
 
@@ -51,6 +52,7 @@ impl ZifTiffEncoder {
             declared_tile_size: None,
             fallback: None,
             force_decoded_fallback: false,
+            source_pyramid: false,
             current_level: 0,
         })
     }
@@ -98,14 +100,30 @@ impl ZifTiffEncoder {
         debug!("Adding level {index} with dimensions {dims:?}, tile size {ts:?}");
         let batch = self
             .writer
-            .add_level(index, LevelConfig::new(dims, (ts.x, ts.y)).map_err(to_io_error)?)
+            .add_level(
+                index,
+                LevelConfig::new(dims, (ts.x, ts.y)).map_err(to_io_error)?,
+            )
             .map_err(to_io_error)?;
         self.output.apply(batch).map_err(to_io_error)
+    }
+
+    fn decode_or_fall_back(&mut self, tile: EncodedTile) -> io::Result<()> {
+        if self.source_pyramid {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "source-pyramid TIFF requires passthrough-compatible JPEG tiles; use --largest for decoded TIFF output",
+            ));
+        }
+        let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        self.add_tile(decoded)
     }
 }
 
 impl Encoder for ZifTiffEncoder {
     fn begin_level(&mut self, level: SourceLevel) -> io::Result<()> {
+        self.source_pyramid = true;
         self.current_level = level.index;
         if let Some(tile_size) = level.tile_size {
             self.declared_tile_size = Some(tile_size);
@@ -138,25 +156,15 @@ impl Encoder for ZifTiffEncoder {
 
     fn add_encoded_tile(&mut self, tile: EncodedTile) -> io::Result<()> {
         if self.fallback.is_some() || self.force_decoded_fallback {
-            let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
-                .map_err(|err| io::Error::other(err.to_string()))?;
-            return self.add_tile(decoded);
+            return self.decode_or_fall_back(tile);
         }
         let codec = match codec_for_format(tile.format) {
             Ok(codec) => codec,
-            Err(_) => {
-                let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
-                    .map_err(|err| io::Error::other(err.to_string()))?;
-                return self.add_tile(decoded);
-            }
+            Err(_) => return self.decode_or_fall_back(tile),
         };
         let (mut color_model, channels) = match color_from_encoded_tile(&tile) {
             Ok(color) => color,
-            Err(_) => {
-                let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
-                    .map_err(|err| io::Error::other(err.to_string()))?;
-                return self.add_tile(decoded);
-            }
+            Err(_) => return self.decode_or_fall_back(tile),
         };
         if codec == Codec::Jpeg {
             color_model = ColorModel::YCbCr;

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -1,0 +1,202 @@
+use std::collections::HashSet;
+use std::io;
+use std::path::PathBuf;
+
+use image::{ColorType, ImageFormat};
+use log::debug;
+use zif_tiff::{Codec, ColorModel};
+
+use crate::Vec2d;
+use crate::encoder::Encoder;
+use crate::tile::{EncodedTile, Tile};
+
+pub struct ZifTiffEncoder {
+    writer: zif_tiff::Writer,
+    output: zif_tiff::std::FileRangeWriter,
+    tile_size: Option<Vec2d>,
+    codec: Option<Codec>,
+    occupied_tiles: HashSet<(u64, u64)>,
+    size: Vec2d,
+}
+
+impl ZifTiffEncoder {
+    pub fn new(destination: PathBuf, size: Vec2d) -> io::Result<Self> {
+        let output = zif_tiff::std::FileRangeWriter::create(destination).map_err(to_io_error)?;
+        Ok(Self {
+            writer: zif_tiff::Writer::new()
+                .dimensions((u64::from(size.x), u64::from(size.y)))
+                // Temporary value; the first tile updates this before the writer is initialized.
+                .tile_size((16, 16))
+                .map_err(to_io_error)?
+                .codec(Codec::Jpeg)
+                .color_model(ColorModel::YCbCr)
+                .channels(3)
+                .map_err(to_io_error)?
+                .build()
+                .map_err(to_io_error)?,
+            output,
+            tile_size: None,
+            codec: None,
+            occupied_tiles: HashSet::new(),
+            size,
+        })
+    }
+
+    fn configure_from_first_tile(&mut self, tile: &EncodedTile) -> io::Result<()> {
+        if self.tile_size.is_some() {
+            return Ok(());
+        }
+
+        let tile_size = tile.size;
+        let codec = codec_for_format(tile.format)?;
+        let (color_model, channels) = color_from_encoded_tile(tile)?;
+        debug!(
+            "Using zif-tiff passthrough encoder: tile size {tile_size}, codec {codec:?}, color {color_model:?}/{channels} channels"
+        );
+        self.writer = zif_tiff::Writer::new()
+            .dimensions((u64::from(self.size.x), u64::from(self.size.y)))
+            .tile_size((tile_size.x, tile_size.y))
+            .map_err(to_io_error)?
+            .codec(codec)
+            .color_model(color_model)
+            .channels(channels)
+            .map_err(to_io_error)?
+            .build()
+            .map_err(to_io_error)?;
+        self.tile_size = Some(tile_size);
+        self.codec = Some(codec);
+        Ok(())
+    }
+}
+
+impl Encoder for ZifTiffEncoder {
+    fn add_tile(&mut self, _tile: Tile) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "zif TIFF passthrough requires encoded tiles",
+        ))
+    }
+
+    fn add_encoded_tile(&mut self, tile: EncodedTile) -> io::Result<()> {
+        self.configure_from_first_tile(&tile)?;
+
+        let expected_size = self.tile_size.expect("configured above");
+        let codec = codec_for_format(tile.format)?;
+        if Some(codec) != self.codec {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cannot mix tile codecs in one zif TIFF",
+            ));
+        }
+        if tile.position.x % expected_size.x != 0 || tile.position.y % expected_size.y != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "tile positions must align to the zif TIFF tile grid",
+            ));
+        }
+
+        let col = u64::from(tile.position.x / expected_size.x);
+        let row = u64::from(tile.position.y / expected_size.y);
+        if !self.occupied_tiles.insert((col, row)) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "overlapping tiles cannot be passed through to zif TIFF",
+            ));
+        }
+
+        self.output
+            .apply(
+                self.writer
+                    .put_tile((col, row), tile.bytes.as_slice())
+                    .map_err(to_io_error)?,
+            )
+            .map_err(to_io_error)
+    }
+
+    fn finalize(&mut self) -> io::Result<()> {
+        if self.tile_size.is_none() {
+            self.output
+                .apply(self.writer.init().map_err(to_io_error)?)
+                .map_err(to_io_error)?;
+        }
+        Ok(())
+    }
+
+    fn size(&self) -> Vec2d {
+        self.size
+    }
+}
+
+fn codec_for_format(format: ImageFormat) -> io::Result<Codec> {
+    match format {
+        ImageFormat::Jpeg => Ok(Codec::Jpeg),
+        ImageFormat::Png => Ok(Codec::Png),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "zif TIFF passthrough supports only JPEG and PNG input tiles",
+        )),
+    }
+}
+
+fn color_from_encoded_tile(tile: &EncodedTile) -> io::Result<(ColorModel, u16)> {
+    match tile.color_type {
+        ColorType::L8 | ColorType::L16 => Ok((ColorModel::BlackIsZero, 1)),
+        ColorType::Rgb8 | ColorType::Rgb16 => Ok((ColorModel::Rgb, 3)),
+        _ if tile.color_type.has_color() => Ok((ColorModel::Rgb, 3)),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "zif TIFF passthrough supports grayscale or RGB-like input tiles",
+        )),
+    }
+}
+
+fn to_io_error(error: zif_tiff::Error) -> io::Error {
+    match error {
+        zif_tiff::Error::Io(e) => e,
+        other => io::Error::other(other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use image::ImageEncoder;
+    use zif_tiff::std::RangeReader;
+
+    use super::*;
+
+    #[test]
+    fn writes_input_tile_bytes_without_reencoding() {
+        let mut encoded_png = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut encoded_png)
+            .write_image(
+                &vec![255; 16 * 16 * 3],
+                16,
+                16,
+                image::ExtendedColorType::Rgb8,
+            )
+            .unwrap();
+        let bytes = Arc::new(encoded_png);
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("passthrough.tiff");
+        let mut encoder = ZifTiffEncoder::new(destination.clone(), Vec2d { x: 16, y: 16 }).unwrap();
+
+        encoder
+            .add_encoded_tile(EncodedTile {
+                position: Vec2d { x: 0, y: 0 },
+                bytes: Arc::clone(&bytes),
+                format: ImageFormat::Png,
+                size: Vec2d { x: 16, y: 16 },
+                color_type: ColorType::Rgb8,
+            })
+            .unwrap();
+        encoder.finalize().unwrap();
+
+        let mut reader = RangeReader::open(&destination).unwrap();
+        let image = reader.read_zif().unwrap();
+        let tile = image.level_tiles(0).unwrap().next().unwrap();
+        let stored = reader.fetch(tile.range()).unwrap();
+        assert_eq!(stored.bytes(), bytes.as_slice());
+    }
+}

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -16,11 +16,13 @@ pub struct ZifTiffEncoder {
     output: zif_tiff::std::FileRangeWriter,
     tile_size: Option<Vec2d>,
     codec: Option<Codec>,
+    color: Option<(ColorModel, u16)>,
     occupied_tiles: HashSet<(usize, u64, u64)>,
     size: Vec2d,
     destination: PathBuf,
     declared_tile_size: Option<Vec2d>,
     fallback: Option<Canvas<Rgba<u8>>>,
+    force_decoded_fallback: bool,
     current_level: usize,
 }
 
@@ -42,11 +44,13 @@ impl ZifTiffEncoder {
             output,
             tile_size: None,
             codec: None,
+            color: None,
             occupied_tiles: HashSet::new(),
             size,
             destination,
             declared_tile_size: None,
             fallback: None,
+            force_decoded_fallback: false,
             current_level: 0,
         })
     }
@@ -75,6 +79,7 @@ impl ZifTiffEncoder {
             .map_err(to_io_error)?;
         self.tile_size = Some(tile_size);
         self.codec = Some(codec);
+        self.color = Some((color_model, channels));
         Ok(())
     }
 }
@@ -85,6 +90,7 @@ impl Encoder for ZifTiffEncoder {
         if let Some(tile_size) = level.tile_size {
             self.declared_tile_size = Some(tile_size);
         }
+        self.force_decoded_fallback |= level.has_overlapping_tiles;
         Ok(())
     }
 
@@ -108,24 +114,40 @@ impl Encoder for ZifTiffEncoder {
     }
 
     fn add_encoded_tile(&mut self, tile: EncodedTile) -> io::Result<()> {
-        if self.fallback.is_some() {
+        if self.fallback.is_some() || self.force_decoded_fallback {
             let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
                 .map_err(|err| io::Error::other(err.to_string()))?;
             return self.add_tile(decoded);
         }
-        if codec_for_format(tile.format).is_err() || color_from_encoded_tile(&tile).is_err() {
-            let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
-                .map_err(|err| io::Error::other(err.to_string()))?;
-            return self.add_tile(decoded);
-        }
+        let codec = match codec_for_format(tile.format) {
+            Ok(codec) => codec,
+            Err(_) => {
+                let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
+                    .map_err(|err| io::Error::other(err.to_string()))?;
+                return self.add_tile(decoded);
+            }
+        };
+        let color = match color_from_encoded_tile(&tile) {
+            Ok(color) => color,
+            Err(_) => {
+                let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
+                    .map_err(|err| io::Error::other(err.to_string()))?;
+                return self.add_tile(decoded);
+            }
+        };
         self.configure_from_first_tile(&tile)?;
 
         let expected_size = self.tile_size.expect("configured above");
-        let codec = codec_for_format(tile.format)?;
         if Some(codec) != self.codec {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "cannot mix tile codecs in one zif TIFF",
+            ));
+        }
+        if Some(color) != self.color {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cannot mix tile color models in one zif TIFF",
             ));
         }
         if !tile.position.x.is_multiple_of(expected_size.x)

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -2,27 +2,31 @@ use std::collections::HashSet;
 use std::io;
 use std::path::PathBuf;
 
-use image::{ColorType, ImageFormat};
+use image::{ColorType, ImageFormat, Rgba};
 use log::debug;
 use zif_tiff::{Codec, ColorModel};
 
 use crate::Vec2d;
+use crate::encoder::canvas::Canvas;
 use crate::encoder::{Encoder, SourceLevel};
-use crate::tile::{EncodedTile, Tile};
+use crate::tile::{EncodedTile, Tile, load_tile_with_metadata};
 
 pub struct ZifTiffEncoder {
     writer: zif_tiff::Writer,
     output: zif_tiff::std::FileRangeWriter,
     tile_size: Option<Vec2d>,
     codec: Option<Codec>,
-    occupied_tiles: HashSet<(u64, u64)>,
+    occupied_tiles: HashSet<(usize, u64, u64)>,
     size: Vec2d,
+    destination: PathBuf,
+    declared_tile_size: Option<Vec2d>,
+    fallback: Option<Canvas<Rgba<u8>>>,
     current_level: usize,
 }
 
 impl ZifTiffEncoder {
     pub fn new(destination: PathBuf, size: Vec2d) -> io::Result<Self> {
-        let output = zif_tiff::std::FileRangeWriter::create(destination).map_err(to_io_error)?;
+        let output = zif_tiff::std::FileRangeWriter::create(&destination).map_err(to_io_error)?;
         Ok(Self {
             writer: zif_tiff::Writer::new()
                 .dimensions((u64::from(size.x), u64::from(size.y)))
@@ -40,6 +44,9 @@ impl ZifTiffEncoder {
             codec: None,
             occupied_tiles: HashSet::new(),
             size,
+            destination,
+            declared_tile_size: None,
+            fallback: None,
             current_level: 0,
         })
     }
@@ -49,7 +56,7 @@ impl ZifTiffEncoder {
             return Ok(());
         }
 
-        let tile_size = tile.size;
+        let tile_size = self.declared_tile_size.unwrap_or(tile.size);
         let codec = codec_for_format(tile.format)?;
         let (color_model, channels) = color_from_encoded_tile(tile)?;
         debug!(
@@ -75,17 +82,42 @@ impl ZifTiffEncoder {
 impl Encoder for ZifTiffEncoder {
     fn begin_level(&mut self, level: SourceLevel) -> io::Result<()> {
         self.current_level = level.index;
+        if let Some(tile_size) = level.tile_size {
+            self.declared_tile_size = Some(tile_size);
+        }
         Ok(())
     }
 
-    fn add_tile(&mut self, _tile: Tile) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "zif TIFF passthrough requires encoded tiles",
-        ))
+    fn add_tile(&mut self, tile: Tile) -> io::Result<()> {
+        if self.tile_size.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "cannot fall back to decoded TIFF after starting zif passthrough",
+            ));
+        }
+        if self.fallback.is_none() {
+            self.fallback = Some(
+                Canvas::<Rgba<u8>>::new_generic(self.destination.clone(), self.size)
+                    .map_err(|err| io::Error::other(err.to_string()))?,
+            );
+        }
+        self.fallback
+            .as_mut()
+            .expect("created above")
+            .add_tile(tile)
     }
 
     fn add_encoded_tile(&mut self, tile: EncodedTile) -> io::Result<()> {
+        if self.fallback.is_some() {
+            let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
+                .map_err(|err| io::Error::other(err.to_string()))?;
+            return self.add_tile(decoded);
+        }
+        if codec_for_format(tile.format).is_err() || color_from_encoded_tile(&tile).is_err() {
+            let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
+                .map_err(|err| io::Error::other(err.to_string()))?;
+            return self.add_tile(decoded);
+        }
         self.configure_from_first_tile(&tile)?;
 
         let expected_size = self.tile_size.expect("configured above");
@@ -105,7 +137,7 @@ impl Encoder for ZifTiffEncoder {
 
         let col = u64::from(tile.position.x / expected_size.x);
         let row = u64::from(tile.position.y / expected_size.y);
-        if !self.occupied_tiles.insert((col, row)) {
+        if !self.occupied_tiles.insert((self.current_level, col, row)) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "overlapping tiles cannot be passed through to zif TIFF",
@@ -122,6 +154,9 @@ impl Encoder for ZifTiffEncoder {
     }
 
     fn finalize(&mut self) -> io::Result<()> {
+        if let Some(fallback) = &mut self.fallback {
+            return fallback.finalize();
+        }
         if self.tile_size.is_none() {
             self.output
                 .apply(self.writer.init().map_err(to_io_error)?)
@@ -150,6 +185,12 @@ fn color_from_encoded_tile(tile: &EncodedTile) -> io::Result<(ColorModel, u16)> 
     match tile.color_type {
         ColorType::L8 | ColorType::L16 => Ok((ColorModel::BlackIsZero, 1)),
         ColorType::Rgb8 | ColorType::Rgb16 => Ok((ColorModel::Rgb, 3)),
+        ColorType::Rgba8 | ColorType::Rgba16 | ColorType::La8 | ColorType::La16 => {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "zif TIFF passthrough does not support alpha-channel tiles",
+            ))
+        }
         _ if tile.color_type.has_color() => Ok((ColorModel::Rgb, 3)),
         _ => Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -22,6 +22,7 @@ pub struct ZifTiffEncoder {
     destination: PathBuf,
     declared_tile_size: Option<Vec2d>,
     fallback: Option<Canvas<Rgba<u8>>>,
+    fallback_destination: Option<PathBuf>,
     force_decoded_fallback: bool,
     source_pyramid: bool,
     current_level: usize,
@@ -51,6 +52,7 @@ impl ZifTiffEncoder {
             destination,
             declared_tile_size: None,
             fallback: None,
+            fallback_destination: None,
             force_decoded_fallback: false,
             source_pyramid: false,
             current_level: 0,
@@ -143,10 +145,12 @@ impl Encoder for ZifTiffEncoder {
             ));
         }
         if self.fallback.is_none() {
+            let fallback_destination = decoded_fallback_destination(&self.destination);
             self.fallback = Some(
-                Canvas::<Rgba<u8>>::new_generic(self.destination.clone(), self.size)
+                Canvas::<Rgba<u8>>::new_generic(fallback_destination.clone(), self.size)
                     .map_err(|err| io::Error::other(err.to_string()))?,
             );
+            self.fallback_destination = Some(fallback_destination);
         }
         self.fallback
             .as_mut()
@@ -214,7 +218,13 @@ impl Encoder for ZifTiffEncoder {
 
     fn finalize(&mut self) -> io::Result<()> {
         if let Some(fallback) = &mut self.fallback {
-            return fallback.finalize();
+            fallback.finalize()?;
+            if let Some(fallback_destination) = &self.fallback_destination {
+                if fallback_destination != &self.destination {
+                    std::fs::rename(fallback_destination, &self.destination)?;
+                }
+            }
+            return Ok(());
         }
         if self.tile_size.is_none() {
             self.output
@@ -226,6 +236,17 @@ impl Encoder for ZifTiffEncoder {
 
     fn size(&self) -> Vec2d {
         self.size
+    }
+}
+
+fn decoded_fallback_destination(destination: &std::path::Path) -> PathBuf {
+    if destination
+        .extension()
+        .is_some_and(|extension| extension == "zif")
+    {
+        destination.with_extension("tiff")
+    } else {
+        destination.to_owned()
     }
 }
 

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -7,7 +7,7 @@ use log::debug;
 use zif_tiff::{Codec, ColorModel};
 
 use crate::Vec2d;
-use crate::encoder::Encoder;
+use crate::encoder::{Encoder, SourceLevel};
 use crate::tile::{EncodedTile, Tile};
 
 pub struct ZifTiffEncoder {
@@ -17,6 +17,7 @@ pub struct ZifTiffEncoder {
     codec: Option<Codec>,
     occupied_tiles: HashSet<(u64, u64)>,
     size: Vec2d,
+    current_level: usize,
 }
 
 impl ZifTiffEncoder {
@@ -39,6 +40,7 @@ impl ZifTiffEncoder {
             codec: None,
             occupied_tiles: HashSet::new(),
             size,
+            current_level: 0,
         })
     }
 
@@ -61,6 +63,7 @@ impl ZifTiffEncoder {
             .color_model(color_model)
             .channels(channels)
             .map_err(to_io_error)?
+            .pyramid()
             .build()
             .map_err(to_io_error)?;
         self.tile_size = Some(tile_size);
@@ -70,6 +73,11 @@ impl ZifTiffEncoder {
 }
 
 impl Encoder for ZifTiffEncoder {
+    fn begin_level(&mut self, level: SourceLevel) -> io::Result<()> {
+        self.current_level = level.index;
+        Ok(())
+    }
+
     fn add_tile(&mut self, _tile: Tile) -> io::Result<()> {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
@@ -107,7 +115,7 @@ impl Encoder for ZifTiffEncoder {
         self.output
             .apply(
                 self.writer
-                    .put_tile((col, row), tile.bytes.as_slice())
+                    .put_tile_at_level(self.current_level, (col, row), tile.bytes.as_slice())
                     .map_err(to_io_error)?,
             )
             .map_err(to_io_error)

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -192,10 +192,14 @@ impl Encoder for ZifTiffEncoder {
         if codec == Codec::Jpeg {
             color_model = ColorModel::YCbCr;
         }
-        let jpeg = match parse_jpeg_tile_info(&tile.bytes) {
-            Ok(jpeg) => jpeg,
-            Err(err) if self.source_pyramid => return Err(err),
-            Err(_) => return self.decode_or_fall_back(tile),
+        let jpeg = if codec == Codec::Jpeg {
+            match parse_jpeg_tile_info(&tile.bytes) {
+                Ok(jpeg) => Some(jpeg),
+                Err(err) if self.source_pyramid => return Err(err),
+                Err(_) => return self.decode_or_fall_back(tile),
+            }
+        } else {
+            None
         };
         let color = (color_model, channels);
         self.configure_from_first_tile(&tile)?;
@@ -213,7 +217,7 @@ impl Encoder for ZifTiffEncoder {
                 "cannot mix tile color models in one zif TIFF",
             ));
         }
-        if Some(jpeg) != self.jpeg {
+        if jpeg != self.jpeg {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "cannot mix JPEG sampling layouts in one zif TIFF",
@@ -307,13 +311,7 @@ fn parse_jpeg_tile_info(bytes: &[u8]) -> io::Result<JpegTileInfo> {
         }
         let segment = &bytes[pos + 2..pos + len];
         match marker {
-            0xc0 => return parse_jpeg_start_of_frame(segment),
-            0xc2 => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "progressive JPEG tiles cannot be passed through to zif TIFF",
-                ));
-            }
+            0xc0 | 0xc1 | 0xc2 => return parse_jpeg_start_of_frame(segment),
             _ => {}
         }
         pos += len;
@@ -468,9 +466,14 @@ mod tests {
     }
 
     #[test]
-    fn rejects_progressive_jpeg_passthrough_metadata() {
+    fn parses_jpeg_subsampling_from_progressive_frame() {
         let jpeg = minimal_jpeg_with_sof(0xc2, 0x22);
-        assert!(parse_jpeg_tile_info(&jpeg).is_err());
+        assert_eq!(
+            parse_jpeg_tile_info(&jpeg).unwrap(),
+            JpegTileInfo {
+                subsampling: (2, 2)
+            }
+        );
     }
 
     fn minimal_jpeg_with_sof(marker: u8, first_component_sampling: u8) -> Vec<u8> {

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use image::{ColorType, ImageFormat, Rgba};
 use log::debug;
-use zif_tiff::{Codec, ColorModel};
+use zif_tiff::{Codec, ColorModel, LevelConfig};
 
 use crate::Vec2d;
 use crate::encoder::canvas::Canvas;
@@ -23,7 +23,6 @@ pub struct ZifTiffEncoder {
     declared_tile_size: Option<Vec2d>,
     fallback: Option<Canvas<Rgba<u8>>>,
     force_decoded_fallback: bool,
-    wants_pyramid: bool,
     current_level: usize,
 }
 
@@ -52,7 +51,6 @@ impl ZifTiffEncoder {
             declared_tile_size: None,
             fallback: None,
             force_decoded_fallback: false,
-            wants_pyramid: false,
             current_level: 0,
         })
     }
@@ -71,33 +69,51 @@ impl ZifTiffEncoder {
         debug!(
             "Using zif-tiff passthrough encoder: tile size {tile_size}, codec {codec:?}, color {color_model:?}/{channels} channels"
         );
-        let mut builder = zif_tiff::Writer::new()
+        self.writer = zif_tiff::Writer::new()
             .dimensions((u64::from(self.size.x), u64::from(self.size.y)))
             .tile_size((tile_size.x, tile_size.y))
             .map_err(to_io_error)?
             .codec(codec)
             .color_model(color_model)
             .channels(channels)
+            .map_err(to_io_error)?
+            .build()
             .map_err(to_io_error)?;
-        if self.wants_pyramid {
-            builder = builder.pyramid();
-        }
-        self.writer = builder.build().map_err(to_io_error)?;
         self.tile_size = Some(tile_size);
         self.codec = Some(codec);
         self.color = Some((color_model, channels));
         Ok(())
     }
+
+    fn add_sub_level(&mut self, index: usize, level: &SourceLevel) -> io::Result<()> {
+        let sf = u64::from(level.scale_factor);
+        let dims = (
+            u64::from(self.size.x).div_ceil(sf),
+            u64::from(self.size.y).div_ceil(sf),
+        );
+        let ts = self
+            .declared_tile_size
+            .or(self.tile_size)
+            .expect("tile size is set before sub-levels arrive");
+        debug!("Adding level {index} with dimensions {dims:?}, tile size {ts:?}");
+        let batch = self
+            .writer
+            .add_level(index, LevelConfig::new(dims, (ts.x, ts.y)).map_err(to_io_error)?)
+            .map_err(to_io_error)?;
+        self.output.apply(batch).map_err(to_io_error)
+    }
 }
 
 impl Encoder for ZifTiffEncoder {
     fn begin_level(&mut self, level: SourceLevel) -> io::Result<()> {
-        self.wants_pyramid = true;
         self.current_level = level.index;
         if let Some(tile_size) = level.tile_size {
             self.declared_tile_size = Some(tile_size);
         }
         self.force_decoded_fallback |= level.has_overlapping_tiles;
+        if self.tile_size.is_some() {
+            self.add_sub_level(level.index, &level)?;
+        }
         Ok(())
     }
 

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -164,6 +164,16 @@ impl Encoder for ZifTiffEncoder {
             ));
         }
         if self.fallback.is_none() {
+            if self
+                .destination
+                .extension()
+                .is_some_and(|extension| extension == "zif")
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "zif output requires passthrough-compatible JPEG tiles; use a .tiff extension for decoded fallback output",
+                ));
+            }
             let fallback_destination = decoded_fallback_destination(&self.destination);
             self.fallback = Some(
                 Canvas::<Rgba<u8>>::new_generic(fallback_destination.clone(), self.size)
@@ -474,6 +484,44 @@ mod tests {
                 subsampling: (2, 2)
             }
         );
+    }
+
+    #[test]
+    fn rejects_decoded_fallback_for_zif_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("fallback.zif");
+        let mut encoder = ZifTiffEncoder::new(destination.clone(), Vec2d { x: 1, y: 1 }).unwrap();
+
+        let err = encoder
+            .add_tile(Tile {
+                position: Vec2d { x: 0, y: 0 },
+                image: image::DynamicImage::new_rgba8(1, 1),
+                icc_profile: None,
+                exif_metadata: None,
+            })
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(!destination.with_extension("tiff").exists());
+    }
+
+    #[test]
+    fn allows_decoded_fallback_for_tiff_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("fallback.tiff");
+        let mut encoder = ZifTiffEncoder::new(destination.clone(), Vec2d { x: 1, y: 1 }).unwrap();
+
+        encoder
+            .add_tile(Tile {
+                position: Vec2d { x: 0, y: 0 },
+                image: image::DynamicImage::new_rgba8(1, 1),
+                icc_profile: None,
+                exif_metadata: None,
+            })
+            .unwrap();
+        encoder.finalize().unwrap();
+
+        assert!(destination.exists());
     }
 
     fn minimal_jpeg_with_sof(marker: u8, first_component_sampling: u8) -> Vec<u8> {

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -62,7 +62,10 @@ impl ZifTiffEncoder {
 
         let tile_size = self.declared_tile_size.unwrap_or(tile.size);
         let codec = codec_for_format(tile.format)?;
-        let (color_model, channels) = color_from_encoded_tile(tile)?;
+        let (mut color_model, channels) = color_from_encoded_tile(tile)?;
+        if codec == Codec::Jpeg {
+            color_model = ColorModel::YCbCr;
+        }
         debug!(
             "Using zif-tiff passthrough encoder: tile size {tile_size}, codec {codec:?}, color {color_model:?}/{channels} channels"
         );
@@ -127,7 +130,7 @@ impl Encoder for ZifTiffEncoder {
                 return self.add_tile(decoded);
             }
         };
-        let color = match color_from_encoded_tile(&tile) {
+        let (mut color_model, channels) = match color_from_encoded_tile(&tile) {
             Ok(color) => color,
             Err(_) => {
                 let decoded = load_tile_with_metadata(tile.position, &tile.bytes)
@@ -135,6 +138,10 @@ impl Encoder for ZifTiffEncoder {
                 return self.add_tile(decoded);
             }
         };
+        if codec == Codec::Jpeg {
+            color_model = ColorModel::YCbCr;
+        }
+        let color = (color_model, channels);
         self.configure_from_first_tile(&tile)?;
 
         let expected_size = self.tile_size.expect("configured above");

--- a/src/encoder/zif_tiff_encoder.rs
+++ b/src/encoder/zif_tiff_encoder.rs
@@ -263,10 +263,10 @@ impl Encoder for ZifTiffEncoder {
     fn finalize(&mut self) -> io::Result<()> {
         if let Some(fallback) = &mut self.fallback {
             fallback.finalize()?;
-            if let Some(fallback_destination) = &self.fallback_destination {
-                if fallback_destination != &self.destination {
-                    std::fs::rename(fallback_destination, &self.destination)?;
-                }
+            if let Some(fallback_destination) = &self.fallback_destination
+                && fallback_destination != &self.destination
+            {
+                std::fs::rename(fallback_destination, &self.destination)?;
             }
             return Ok(());
         }
@@ -320,9 +320,8 @@ fn parse_jpeg_tile_info(bytes: &[u8]) -> io::Result<JpegTileInfo> {
             break;
         }
         let segment = &bytes[pos + 2..pos + len];
-        match marker {
-            0xc0 | 0xc1 | 0xc2 => return parse_jpeg_start_of_frame(segment),
-            _ => {}
+        if let 0xc0..=0xc2 = marker {
+            return parse_jpeg_start_of_frame(segment);
         }
         pos += len;
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::error::SendError;
 
 custom_error! {
     pub ZoomError
-    Networking{source: reqwest::Error} = "network error: {source}",
+    Networking{source: reqwest::Error, details: String} = "{details}",
     Dezoomer{source: DezoomerError} = "Dezoomer error: {source}",
     NoLevels = "A zoomable image was found, but it did not contain any zoom level",
     NoBulkUrl { bulk_file_path: String } = "No url found in bulk file {bulk_file_path}",
@@ -34,6 +34,28 @@ custom_error! {
     BufferToImage{source: BufferToImageError} = "{source}",
     WriteError{source: SendError<TileBufferMsg>} = "Unable to write tile {source:?}",
     PngError{source: png::EncodingError} = "PNG encoding error: {source}",
+}
+
+impl From<reqwest::Error> for ZoomError {
+    fn from(source: reqwest::Error) -> Self {
+        let message = source.to_string();
+        let mut cause = source.source();
+        while let Some(next) = cause.and_then(Error::source) {
+            cause = Some(next);
+        }
+        let root_cause = cause.map(|cause| {
+            let message = cause.to_string();
+            message
+                .split_once(" (os error ")
+                .map_or(message.as_str(), |(message, _)| message)
+                .to_string()
+        });
+        let details = match root_cause {
+            Some(root_cause) if root_cause != message => format!("{message}: {root_cause}"),
+            _ => message,
+        };
+        Self::Networking { source, details }
+    }
 }
 
 custom_error! {

--- a/src/google_arts_and_culture/mod.rs
+++ b/src/google_arts_and_culture/mod.rs
@@ -134,7 +134,7 @@ fn post_process_tile(
 
 impl std::fmt::Debug for GAPZoomLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", &self.page_info.name)
+        write!(f, "{}", self.page_info.name)
     }
 }
 

--- a/src/iiif/mod.rs
+++ b/src/iiif/mod.rs
@@ -299,6 +299,10 @@ impl TilesRect for IIIFZoomLevel {
             format = self.format,
         )
     }
+
+    fn scale_factor_hint(&self) -> Option<u32> {
+        Some(self.scale_factor)
+    }
 }
 
 struct TileSizeFormatter {

--- a/src/iiif/mod.rs
+++ b/src/iiif/mod.rs
@@ -105,13 +105,9 @@ impl Dezoomer for IIIF {
             match type_str {
                 "ImageService2" | "ImageService3" | "iiif:ImageProfile" => {
                     // This is clearly an Image Service info.json, try parsing it directly
-                    match zoom_levels(uri, contents) {
-                        Ok(levels) => {
-                            let image = IIIFZoomableImage::new(levels, None);
-                            return Ok(dezoomer_result_from_single_image(image));
-                        }
-                        Err(e) => return Err(e.into()),
-                    }
+                    let levels = zoom_levels(uri, contents)?;
+                    let image = IIIFZoomableImage::new(levels, None);
+                    return Ok(dezoomer_result_from_single_image(image));
                 }
                 "Manifest" | "sc:Manifest" => {
                     // This is clearly a manifest, try parsing it as such

--- a/src/krpano/krpano_metadata.rs
+++ b/src/krpano/krpano_metadata.rs
@@ -74,13 +74,17 @@ impl KrpanoMetadata {
             let s = [name.as_ref(), &self.name].join(" ");
             Arc::from(s)
         };
-        let images = self.image.into_iter().filter(|image| image.has_tile_levels()).map({
-            let name = Arc::clone(&name);
-            move |image| ImageInfo {
-                image,
-                name: Arc::clone(&name),
-            }
-        });
+        let images = self
+            .image
+            .into_iter()
+            .filter(|image| image.has_tile_levels())
+            .map({
+                let name = Arc::clone(&name);
+                move |image| ImageInfo {
+                    image,
+                    name: Arc::clone(&name),
+                }
+            });
         let scene_images = self
             .scene
             .into_iter()
@@ -97,9 +101,11 @@ impl KrpanoMetadata {
             .iter()
             .find_map(|details| (!details.subject.is_empty()).then_some(details.subject.as_str()))
             .or_else(|| {
-                self.data
-                    .iter()
-                    .find_map(|bytes| serde_json::from_str::<KrpanoMetaData>(bytes).ok().map(|m| m.title))
+                self.data.iter().find_map(|bytes| {
+                    serde_json::from_str::<KrpanoMetaData>(bytes)
+                        .ok()
+                        .map(|m| m.title)
+                })
             })
     }
 }
@@ -159,7 +165,8 @@ impl KrpanoImage {
     }
 
     fn into_all_levels(self) -> impl Iterator<Item = KrpanoLevel> {
-        self.level.into_iter()
+        self.level
+            .into_iter()
             .chain(self.cube.into_iter().map(KrpanoLevel::Cube))
             .chain(self.cylinder.into_iter().map(KrpanoLevel::Cylinder))
             .chain(self.flat.into_iter().map(KrpanoLevel::Flat))
@@ -599,9 +606,7 @@ mod test {
             image.into_levels().collect::<Vec<_>>(),
             vec![KrpanoLevel::Flat(ShapeDesc {
                 url: TemplateString(vec![str("https://example.com/"),]),
-                multires: Some(
-                    "512,768x554,1664x1202,3200x2310,6400x4618,12800x9234".to_string()
-                ),
+                multires: Some("512,768x554,1664x1202,3200x2310,6400x4618,12800x9234".to_string()),
             })]
         )
     }
@@ -673,7 +678,8 @@ mod test {
 
     #[test]
     fn parse_panotour_xml_with_interleaved_unknown_tags() {
-        let parsed = KrpanoMetadata::from_str(r#"<krpano version="1.19">
+        let parsed = KrpanoMetadata::from_str(
+            r#"<krpano version="1.19">
             <security><allowdomain domain="*" /></security>
             <events name="startbehavioursevents" />
             <include url="%FIRSTXML%/index_skin.xml" />
@@ -695,7 +701,8 @@ mod test {
                 </image>
             </scene>
             <krpano nofullspherepanoavailable="false" />
-        </krpano>"#)
+        </krpano>"#,
+        )
         .unwrap();
 
         let infos: Vec<ImageInfo> = parsed.into_image_iter().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ async fn get_dezoomer_result(
             Ok(result) => return Ok(result),
             Err(DezoomerError::NeedsData { uri }) => {
                 let contents = fetch_uri(&uri, http).await.into();
-                debug!("Response for metadata file '{}': {:?}", uri, &contents);
+                debug!("Response for metadata file '{}': {:?}", uri, contents);
                 i.uri = uri;
                 i.contents = contents;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,16 +256,16 @@ fn output_prefers_source_pyramid(path: &Path, args: &Arguments) -> bool {
 
 async fn dezoomify_source_pyramid(
     args: &Arguments,
-    levels: Vec<ZoomLevel>,
+    mut levels: Vec<ZoomLevel>,
     tile_buffer: TileBuffer,
 ) -> Result<(), ZoomError> {
     let mut canvas = tile_buffer;
-    let full_size = levels
-        .last()
-        .and_then(|level| level.size_hint())
-        .ok_or(ZoomError::NoLevels)?;
+    let full_size = largest_level_size(&levels).ok_or(ZoomError::NoLevels)?;
+    levels.sort_by_key(|level| std::cmp::Reverse(level_area(level.size_hint())));
 
-    for (index, zoom_level) in levels.into_iter().rev().enumerate() {
+    let mut total_tiles = 0;
+    let mut successful_tiles = 0;
+    for (index, zoom_level) in levels.into_iter().enumerate() {
         let level_size = zoom_level.size_hint().unwrap_or(full_size);
         let scale_factor = full_size.x.div_ceil(level_size.x).max(1);
         canvas
@@ -278,9 +278,32 @@ async fn dezoomify_source_pyramid(
             .await?;
         let state = dezoomify_level_into_buffer(args, zoom_level, &mut canvas).await?;
         validate_download_success(&state)?;
+        total_tiles += state.total_tiles;
+        successful_tiles += state.successful_tiles;
     }
 
-    finalize_canvas(&mut canvas).await
+    finalize_canvas(&mut canvas).await?;
+    if successful_tiles < total_tiles {
+        Err(ZoomError::PartialDownload {
+            successful_tiles,
+            total_tiles,
+            destination: canvas.destination().to_string_lossy().to_string(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn largest_level_size(levels: &[ZoomLevel]) -> Option<Vec2d> {
+    levels
+        .iter()
+        .filter_map(|level| level.size_hint())
+        .max_by_key(|size| level_area(Some(*size)))
+}
+
+fn level_area(size: Option<Vec2d>) -> u64 {
+    size.map(|size| u64::from(size.x) * u64::from(size.y))
+        .unwrap_or(0)
 }
 
 pub async fn dezoomify(args: &Arguments) -> Result<PathBuf, ZoomError> {
@@ -298,7 +321,7 @@ pub async fn dezoomify(args: &Arguments) -> Result<PathBuf, ZoomError> {
 
     let base_dir = current_dir()?;
     let output_file = args.output_file();
-    let largest_size = zoom_levels.last().and_then(|level| level.size_hint());
+    let largest_size = largest_level_size(&zoom_levels);
     let save_as = prepare_output_path(&output_file, &title, &base_dir, largest_size)?;
     let tile_buffer = create_tile_buffer(save_as.clone(), args.compression).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,7 @@ async fn dezoomify_source_pyramid(
                 index,
                 size: full_size,
                 scale_factor,
+                tile_size: zoom_level.tile_size_hint(),
             })
             .await?;
         let state = dezoomify_level_into_buffer(args, zoom_level, &mut canvas).await?;
@@ -301,7 +302,7 @@ pub async fn dezoomify(args: &Arguments) -> Result<PathBuf, ZoomError> {
     let save_as = prepare_output_path(&output_file, &title, &base_dir, largest_size)?;
     let tile_buffer = create_tile_buffer(save_as.clone(), args.compression).await?;
 
-    if output_prefers_source_pyramid(&save_as, args) && zoom_levels.len() > 1 {
+    if output_prefers_source_pyramid(&save_as, args) {
         info!("Dezooming source pyramid with {} levels", zoom_levels.len());
         dezoomify_source_pyramid(args, zoom_levels, tile_buffer).await?;
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,7 @@ async fn dezoomify_source_pyramid(
                 size: full_size,
                 scale_factor,
                 tile_size: zoom_level.tile_size_hint(),
+                has_overlapping_tiles: zoom_level.has_overlapping_tiles(),
             })
             .await?;
         let state = dezoomify_level_into_buffer(args, zoom_level, &mut canvas).await?;
@@ -322,18 +323,22 @@ pub async fn dezoomify(args: &Arguments) -> Result<PathBuf, ZoomError> {
     let base_dir = current_dir()?;
     let output_file = args.output_file();
     let largest_size = largest_level_size(&zoom_levels);
-    let save_as = prepare_output_path(&output_file, &title, &base_dir, largest_size)?;
-    let tile_buffer = create_tile_buffer(save_as.clone(), args.compression).await?;
+    let source_pyramid_path = get_outname(&output_file, &title, &base_dir, largest_size);
 
-    if output_prefers_source_pyramid(&save_as, args) {
+    if output_prefers_source_pyramid(&source_pyramid_path, args) {
+        let save_as = prepare_output_path(&output_file, &title, &base_dir, largest_size)?;
+        let tile_buffer = create_tile_buffer(save_as.clone(), args.compression).await?;
         info!("Dezooming source pyramid with {} levels", zoom_levels.len());
         dezoomify_source_pyramid(args, zoom_levels, tile_buffer).await?;
+        Ok(save_as)
     } else {
         let zoom_level = choose_level(zoom_levels, args)?;
+        let save_as = prepare_output_path(&output_file, &title, &base_dir, zoom_level.size_hint())?;
+        let tile_buffer = create_tile_buffer(save_as.clone(), args.compression).await?;
         info!("Dezooming {}", zoom_level.name());
         dezoomify_level(args, zoom_level, tile_buffer).await?;
+        Ok(save_as)
     }
-    Ok(save_as)
 }
 
 /// Statistics for bulk processing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use tile::Tile;
 pub use vec2d::Vec2d;
 
 use crate::dezoomer::{DezoomerResult, PageContents, ZoomableImage};
+use crate::encoder::SourceLevel;
 use crate::encoder::tile_buffer::TileBuffer;
 
 use crate::output_file::reserve_output_file;
@@ -225,31 +226,6 @@ fn choose_image(
     }
 }
 
-/// Finds the appropriate zoomlevel for a given size if one is specified,
-async fn find_zoomlevel(args: &Arguments) -> Result<ZoomLevel, ZoomError> {
-    let uri = args.choose_input_uri()?;
-    let http_client = client(args.headers(), args, Some(&uri))?;
-    debug!("Trying to locate a zoomable image...");
-
-    // Use the new unified processing pipeline
-    let images = get_images_from_uri(args, &http_client, &uri).await?;
-    debug!("Found {} zoomable images", images.len());
-
-    // Select an image from the available options (before resolving)
-    let selected_image = choose_image(images, args)?;
-    debug!("Selected image: {:?}", selected_image.title());
-
-    // NOW resolve the selected image to get its zoom levels
-    let zoom_levels = selected_image
-        .into_zoom_levels(&http_client)
-        .await
-        .map_err(|e| ZoomError::Dezoomer { source: e })?;
-    debug!("Extracted {} zoom levels", zoom_levels.len());
-
-    // Select a zoom level from the available options
-    choose_level(zoom_levels, args)
-}
-
 /// Prepares the output file path for saving
 fn prepare_output_path(
     outfile_arg: &Option<PathBuf>,
@@ -268,19 +244,71 @@ async fn create_tile_buffer(save_as: PathBuf, compression: u8) -> Result<TileBuf
     TileBuffer::new(save_as, compression).await
 }
 
+fn output_prefers_source_pyramid(path: &Path, args: &Arguments) -> bool {
+    if args.has_level_specifying_args() || args.largest {
+        return false;
+    }
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("iiif" | "tif" | "tiff")
+    )
+}
+
+async fn dezoomify_source_pyramid(
+    args: &Arguments,
+    levels: Vec<ZoomLevel>,
+    tile_buffer: TileBuffer,
+) -> Result<(), ZoomError> {
+    let mut canvas = tile_buffer;
+    let full_size = levels
+        .last()
+        .and_then(|level| level.size_hint())
+        .ok_or(ZoomError::NoLevels)?;
+
+    for (index, zoom_level) in levels.into_iter().rev().enumerate() {
+        let level_size = zoom_level.size_hint().unwrap_or(full_size);
+        let scale_factor = full_size.x.div_ceil(level_size.x).max(1);
+        canvas
+            .begin_level(SourceLevel {
+                index,
+                size: full_size,
+                scale_factor,
+            })
+            .await?;
+        let state = dezoomify_level_into_buffer(args, zoom_level, &mut canvas).await?;
+        validate_download_success(&state)?;
+    }
+
+    finalize_canvas(&mut canvas).await
+}
+
 pub async fn dezoomify(args: &Arguments) -> Result<PathBuf, ZoomError> {
-    let zoom_level = find_zoomlevel(args).await?;
+    let uri = args.choose_input_uri()?;
+    let http_client = client(args.headers(), args, Some(&uri))?;
+    debug!("Trying to locate a zoomable image...");
+    let images = get_images_from_uri(args, &http_client, &uri).await?;
+    debug!("Found {} zoomable images", images.len());
+    let selected_image = choose_image(images, args)?;
+    let title = selected_image.title().map(|title| title.into_owned());
+    let zoom_levels = selected_image
+        .into_zoom_levels(&http_client)
+        .await
+        .map_err(|e| ZoomError::Dezoomer { source: e })?;
+
     let base_dir = current_dir()?;
     let output_file = args.output_file();
-    let save_as = prepare_output_path(
-        &output_file,
-        &zoom_level.title(),
-        &base_dir,
-        zoom_level.size_hint(),
-    )?;
+    let largest_size = zoom_levels.last().and_then(|level| level.size_hint());
+    let save_as = prepare_output_path(&output_file, &title, &base_dir, largest_size)?;
     let tile_buffer = create_tile_buffer(save_as.clone(), args.compression).await?;
-    info!("Dezooming {}", zoom_level.name());
-    dezoomify_level(args, zoom_level, tile_buffer).await?;
+
+    if output_prefers_source_pyramid(&save_as, args) && zoom_levels.len() > 1 {
+        info!("Dezooming source pyramid with {} levels", zoom_levels.len());
+        dezoomify_source_pyramid(args, zoom_levels, tile_buffer).await?;
+    } else {
+        let zoom_level = choose_level(zoom_levels, args)?;
+        info!("Dezooming {}", zoom_level.name());
+        dezoomify_level(args, zoom_level, tile_buffer).await?;
+    }
     Ok(save_as)
 }
 
@@ -587,11 +615,23 @@ fn determine_final_result(
 
 pub async fn dezoomify_level(
     args: &Arguments,
-    mut zoom_level: ZoomLevel,
+    zoom_level: ZoomLevel,
     tile_buffer: TileBuffer,
 ) -> Result<(), ZoomError> {
     debug!("Starting to dezoomify {zoom_level:?}");
     let mut canvas = tile_buffer;
+    let state = dezoomify_level_into_buffer(args, zoom_level, &mut canvas).await?;
+    validate_download_success(&state)?;
+    finalize_canvas(&mut canvas).await?;
+    let destination = canvas.destination().to_string_lossy().to_string();
+    determine_final_result(&state, destination)
+}
+
+async fn dezoomify_level_into_buffer(
+    args: &Arguments,
+    mut zoom_level: ZoomLevel,
+    canvas: &mut TileBuffer,
+) -> Result<download_state::DownloadState, ZoomError> {
     let mut coordinator = download_state::TileDownloadCoordinator::new(&zoom_level, args)?;
     let mut state = download_state::DownloadState::new();
     let progress = download_state::ProgressManager::new();
@@ -602,26 +642,22 @@ pub async fn dezoomify_level(
 
     while let Some(tile_refs) = zoom_level_iter.next_tile_references() {
         coordinator
-            .download_batch(
-                tile_refs,
-                &mut canvas,
-                &mut state,
-                &progress,
-                &zoom_level_iter,
-            )
+            .download_batch(tile_refs, canvas, &mut state, &progress, &zoom_level_iter)
             .await?;
 
         zoom_level_iter.set_fetch_result(state.create_fetch_result());
     }
 
-    validate_download_success(&state)?;
+    progress.finish();
+    Ok(state)
+}
 
+async fn finalize_canvas(canvas: &mut TileBuffer) -> Result<(), ZoomError> {
+    let progress = download_state::ProgressManager::new();
     progress.set_finalizing();
     canvas.finalize().await?;
     progress.finish();
-
-    let destination = canvas.destination().to_string_lossy().to_string();
-    determine_final_result(&state, destination)
+    Ok(())
 }
 
 /// Returns the maximal size a tile can have in order to fit in a canvas of the given size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,13 +271,21 @@ async fn dezoomify_source_pyramid(
 ) -> Result<(), ZoomError> {
     let mut canvas = tile_buffer;
     let full_size = largest_level_size(&levels).ok_or(ZoomError::NoLevels)?;
+    let base_scale_factor = levels
+        .iter()
+        .filter(|level| level.size_hint() == Some(full_size))
+        .filter_map(|level| level.scale_factor_hint())
+        .filter(|&scale_factor| scale_factor > 0)
+        .min()
+        .unwrap_or(1);
     levels.sort_by_key(|level| std::cmp::Reverse(level_area(level.size_hint())));
 
     let mut total_tiles = 0;
     let mut successful_tiles = 0;
     for (index, zoom_level) in levels.into_iter().enumerate() {
         let level_size = zoom_level.size_hint().unwrap_or(full_size);
-        let scale_factor = source_level_scale_factor(full_size, level_size, &zoom_level);
+        let scale_factor =
+            source_level_scale_factor(full_size, level_size, &zoom_level, base_scale_factor);
         canvas
             .begin_level(SourceLevel {
                 index,
@@ -305,11 +313,33 @@ async fn dezoomify_source_pyramid(
     }
 }
 
-fn source_level_scale_factor(full_size: Vec2d, level_size: Vec2d, level: &ZoomLevel) -> u32 {
-    level
-        .scale_factor_hint()
+fn source_level_scale_factor(
+    full_size: Vec2d,
+    level_size: Vec2d,
+    level: &ZoomLevel,
+    base_scale_factor: u32,
+) -> u32 {
+    source_level_scale_factor_from_hint(
+        full_size,
+        level_size,
+        level.scale_factor_hint(),
+        base_scale_factor,
+    )
+}
+
+fn source_level_scale_factor_from_hint(
+    full_size: Vec2d,
+    level_size: Vec2d,
+    scale_factor_hint: Option<u32>,
+    base_scale_factor: u32,
+) -> u32 {
+    if let Some(scale_factor) = scale_factor_hint
         .filter(|&scale_factor| scale_factor > 0)
-        .unwrap_or_else(|| full_size.x.div_ceil(level_size.x).max(1))
+        .filter(|scale_factor| scale_factor % base_scale_factor == 0)
+    {
+        return (scale_factor / base_scale_factor).max(1);
+    }
+    full_size.x.div_ceil(level_size.x).max(1)
 }
 
 fn largest_level_size(levels: &[ZoomLevel]) -> Option<Vec2d> {
@@ -794,6 +824,50 @@ mod tests {
                 Vec2d { x: 100, y: 100 }
             ),
             Vec2d { x: 100, y: 100 }
+        );
+    }
+
+    #[test]
+    fn source_level_scale_factor_uses_relative_hints() {
+        assert_eq!(
+            source_level_scale_factor_from_hint(
+                Vec2d { x: 5156, y: 3816 },
+                Vec2d { x: 2578, y: 1908 },
+                Some(2),
+                1,
+            ),
+            2
+        );
+        assert_eq!(
+            source_level_scale_factor_from_hint(
+                Vec2d { x: 515, y: 381 },
+                Vec2d { x: 515, y: 381 },
+                Some(10),
+                10,
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn source_level_scale_factor_falls_back_for_unusable_hints() {
+        assert_eq!(
+            source_level_scale_factor_from_hint(
+                Vec2d { x: 5156, y: 3816 },
+                Vec2d { x: 2578, y: 1908 },
+                None,
+                1,
+            ),
+            2
+        );
+        assert_eq!(
+            source_level_scale_factor_from_hint(
+                Vec2d { x: 5156, y: 3816 },
+                Vec2d { x: 2578, y: 1908 },
+                Some(3),
+                2,
+            ),
+            2
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,16 @@ fn output_prefers_source_pyramid(path: &Path, args: &Arguments) -> bool {
     )
 }
 
+fn can_dezoomify_source_pyramid(path: &Path, args: &Arguments, levels: &[ZoomLevel]) -> bool {
+    output_prefers_source_pyramid(path, args)
+        && largest_level_size(levels).is_some()
+        && levels.iter().all(|level| {
+            level.size_hint().is_some()
+                && level.tile_size_hint().is_some()
+                && !level.has_overlapping_tiles()
+        })
+}
+
 async fn dezoomify_source_pyramid(
     args: &Arguments,
     mut levels: Vec<ZoomLevel>,
@@ -267,7 +277,7 @@ async fn dezoomify_source_pyramid(
     let mut successful_tiles = 0;
     for (index, zoom_level) in levels.into_iter().enumerate() {
         let level_size = zoom_level.size_hint().unwrap_or(full_size);
-        let scale_factor = full_size.x.div_ceil(level_size.x).max(1);
+        let scale_factor = source_level_scale_factor(full_size, level_size, &zoom_level);
         canvas
             .begin_level(SourceLevel {
                 index,
@@ -293,6 +303,13 @@ async fn dezoomify_source_pyramid(
     } else {
         Ok(())
     }
+}
+
+fn source_level_scale_factor(full_size: Vec2d, level_size: Vec2d, level: &ZoomLevel) -> u32 {
+    level
+        .scale_factor_hint()
+        .filter(|&scale_factor| scale_factor > 0)
+        .unwrap_or_else(|| full_size.x.div_ceil(level_size.x).max(1))
 }
 
 fn largest_level_size(levels: &[ZoomLevel]) -> Option<Vec2d> {
@@ -325,7 +342,7 @@ pub async fn dezoomify(args: &Arguments) -> Result<PathBuf, ZoomError> {
     let largest_size = largest_level_size(&zoom_levels);
     let source_pyramid_path = get_outname(&output_file, &title, &base_dir, largest_size);
 
-    if output_prefers_source_pyramid(&source_pyramid_path, args) {
+    if can_dezoomify_source_pyramid(&source_pyramid_path, args, &zoom_levels) {
         let save_as = prepare_output_path(&output_file, &title, &base_dir, largest_size)?;
         let tile_buffer = create_tile_buffer(save_as.clone(), args.compression).await?;
         info!("Dezooming source pyramid with {} levels", zoom_levels.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@ fn output_prefers_source_pyramid(path: &Path, args: &Arguments) -> bool {
     }
     matches!(
         path.extension().and_then(|ext| ext.to_str()),
-        Some("iiif" | "tif" | "tiff")
+        Some("iiif" | "tif" | "tiff" | "zif")
     )
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -15,7 +15,6 @@ use crate::binary_display::display_bytes;
 use crate::dezoomer::{PostProcessFn, TileReference};
 use crate::errors::BufferToImageError;
 use crate::errors::{TileDownloadError, ZoomError};
-use crate::tile::{EncodedTile, Tile, load_encoded_tile, load_image_with_metadata};
 
 /// Fetch data, either from an URL or a path to a local file.
 /// If uri doesnt start with "http(s)://", it is considered to be a path
@@ -58,6 +57,12 @@ pub async fn fetch_uri(uri: &str, http: &Client) -> Result<Vec<u8>, ZoomError> {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DownloadedTile {
+    pub position: crate::Vec2d,
+    pub bytes: Arc<Vec<u8>>,
+}
+
 pub struct TileDownloader {
     pub http_client: reqwest::Client,
     pub post_process_fn: PostProcessFn,
@@ -70,9 +75,7 @@ impl TileDownloader {
     pub async fn download_tile(
         &self,
         tile_reference: TileReference,
-    ) -> Result<Tile, TileDownloadError> {
-        // The initial delay after which a failed request is retried depends on the position of the tile
-        // in order to avoid sending repeated "bursts" of requests to a server that is struggling
+    ) -> Result<DownloadedTile, TileDownloadError> {
         let n = 100;
         let idx: f64 = ((tile_reference.position.x + tile_reference.position.y) % n).into();
         let tile_reference = Arc::new(tile_reference);
@@ -80,39 +83,7 @@ impl TileDownloader {
             + Duration::from_secs_f64(idx * self.retry_delay.as_secs_f64() / n as f64);
         let mut failures: usize = 0;
         loop {
-            match self.load_image(Arc::clone(&tile_reference)).await {
-                Ok(tile) => {
-                    return Ok(tile);
-                }
-                Err(cause) => {
-                    if failures >= self.retries {
-                        return Err(TileDownloadError {
-                            tile_reference: Arc::try_unwrap(tile_reference)
-                                .expect("tile reference shouldn't leak"),
-                            cause,
-                        });
-                    }
-                    failures += 1;
-                    warn!("{cause}. Retrying tile download in {wait_time:?}.");
-                    tokio::time::sleep(wait_time).await;
-                    wait_time *= 2;
-                }
-            }
-        }
-    }
-
-    pub async fn download_encoded_tile(
-        &self,
-        tile_reference: TileReference,
-    ) -> Result<EncodedTile, TileDownloadError> {
-        let n = 100;
-        let idx: f64 = ((tile_reference.position.x + tile_reference.position.y) % n).into();
-        let tile_reference = Arc::new(tile_reference);
-        let mut wait_time = self.retry_delay
-            + Duration::from_secs_f64(idx * self.retry_delay.as_secs_f64() / n as f64);
-        let mut failures: usize = 0;
-        loop {
-            match self.load_encoded_image(Arc::clone(&tile_reference)).await {
+            match self.load_tile_bytes(Arc::clone(&tile_reference)).await {
                 Ok(tile) => return Ok(tile),
                 Err(cause) => {
                     if failures >= self.retries {
@@ -131,33 +102,10 @@ impl TileDownloader {
         }
     }
 
-    async fn load_image(&self, tile_reference: Arc<TileReference>) -> Result<Tile, ZoomError> {
-        let bytes = if let Some(bytes) = self.read_from_tile_cache(&tile_reference.url).await {
-            bytes
-        } else {
-            let bytes = self
-                .download_image_bytes(Arc::clone(&tile_reference))
-                .await?;
-            self.write_to_tile_cache(&tile_reference.url, &bytes).await;
-            bytes
-        };
-
-        let position = tile_reference.position;
-        let image_with_metadata =
-            tokio::task::spawn_blocking(move || load_image_with_metadata(&bytes)).await??;
-
-        Ok(Tile::builder()
-            .with_image(image_with_metadata.image)
-            .at_position(position)
-            .with_optional_icc_profile(image_with_metadata.icc_profile)
-            .with_optional_exif_metadata(image_with_metadata.exif_metadata)
-            .build())
-    }
-
-    async fn load_encoded_image(
+    async fn load_tile_bytes(
         &self,
         tile_reference: Arc<TileReference>,
-    ) -> Result<EncodedTile, ZoomError> {
+    ) -> Result<DownloadedTile, ZoomError> {
         let bytes = if let Some(bytes) = self.read_from_tile_cache(&tile_reference.url).await {
             bytes
         } else {
@@ -168,11 +116,10 @@ impl TileDownloader {
             bytes
         };
 
-        let position = tile_reference.position;
-        let bytes = Arc::new(bytes);
-        let mut encoded = tokio::task::spawn_blocking(move || load_encoded_tile(bytes)).await??;
-        encoded.position = position;
-        Ok(encoded)
+        Ok(DownloadedTile {
+            position: tile_reference.position,
+            bytes: Arc::new(bytes),
+        })
     }
 
     async fn download_image_bytes(

--- a/src/network.rs
+++ b/src/network.rs
@@ -185,6 +185,7 @@ pub fn client<'a, I: Iterator<Item = (&'a String, &'a String)>>(
         .collect::<Result<header::HeaderMap, ZoomError>>()?;
     debug!("Creating an http client with the following headers: {header_map:?}");
     let client = reqwest::Client::builder()
+        .use_native_tls()
         .http1_title_case_headers()
         .default_headers(header_map)
         .referer(false)

--- a/src/network.rs
+++ b/src/network.rs
@@ -15,7 +15,7 @@ use crate::binary_display::display_bytes;
 use crate::dezoomer::{PostProcessFn, TileReference};
 use crate::errors::BufferToImageError;
 use crate::errors::{TileDownloadError, ZoomError};
-use crate::tile::{Tile, load_image_with_metadata};
+use crate::tile::{EncodedTile, Tile, load_encoded_tile, load_image_with_metadata};
 
 /// Fetch data, either from an URL or a path to a local file.
 /// If uri doesnt start with "http(s)://", it is considered to be a path
@@ -101,6 +101,36 @@ impl TileDownloader {
         }
     }
 
+    pub async fn download_encoded_tile(
+        &self,
+        tile_reference: TileReference,
+    ) -> Result<EncodedTile, TileDownloadError> {
+        let n = 100;
+        let idx: f64 = ((tile_reference.position.x + tile_reference.position.y) % n).into();
+        let tile_reference = Arc::new(tile_reference);
+        let mut wait_time = self.retry_delay
+            + Duration::from_secs_f64(idx * self.retry_delay.as_secs_f64() / n as f64);
+        let mut failures: usize = 0;
+        loop {
+            match self.load_encoded_image(Arc::clone(&tile_reference)).await {
+                Ok(tile) => return Ok(tile),
+                Err(cause) => {
+                    if failures >= self.retries {
+                        return Err(TileDownloadError {
+                            tile_reference: Arc::try_unwrap(tile_reference)
+                                .expect("tile reference shouldn't leak"),
+                            cause,
+                        });
+                    }
+                    failures += 1;
+                    warn!("{cause}. Retrying tile download in {wait_time:?}.");
+                    tokio::time::sleep(wait_time).await;
+                    wait_time *= 2;
+                }
+            }
+        }
+    }
+
     async fn load_image(&self, tile_reference: Arc<TileReference>) -> Result<Tile, ZoomError> {
         let bytes = if let Some(bytes) = self.read_from_tile_cache(&tile_reference.url).await {
             bytes
@@ -122,6 +152,27 @@ impl TileDownloader {
             .with_optional_icc_profile(image_with_metadata.icc_profile)
             .with_optional_exif_metadata(image_with_metadata.exif_metadata)
             .build())
+    }
+
+    async fn load_encoded_image(
+        &self,
+        tile_reference: Arc<TileReference>,
+    ) -> Result<EncodedTile, ZoomError> {
+        let bytes = if let Some(bytes) = self.read_from_tile_cache(&tile_reference.url).await {
+            bytes
+        } else {
+            let bytes = self
+                .download_image_bytes(Arc::clone(&tile_reference))
+                .await?;
+            self.write_to_tile_cache(&tile_reference.url, &bytes).await;
+            bytes
+        };
+
+        let position = tile_reference.position;
+        let bytes = Arc::new(bytes);
+        let mut encoded = tokio::task::spawn_blocking(move || load_encoded_tile(bytes)).await??;
+        encoded.position = position;
+        Ok(encoded)
     }
 
     async fn download_image_bytes(

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::iter::once;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -72,10 +73,15 @@ pub struct TileDownloader {
 }
 
 impl TileDownloader {
-    pub async fn download_tile(
+    pub async fn download_tile_and_then<T, F, Fut>(
         &self,
         tile_reference: TileReference,
-    ) -> Result<DownloadedTile, TileDownloadError> {
+        mut process: F,
+    ) -> Result<T, TileDownloadError>
+    where
+        F: FnMut(DownloadedTile) -> Fut,
+        Fut: Future<Output = Result<T, ZoomError>>,
+    {
         let n = 100;
         let idx: f64 = ((tile_reference.position.x + tile_reference.position.y) % n).into();
         let tile_reference = Arc::new(tile_reference);
@@ -83,8 +89,12 @@ impl TileDownloader {
             + Duration::from_secs_f64(idx * self.retry_delay.as_secs_f64() / n as f64);
         let mut failures: usize = 0;
         loop {
-            match self.load_tile_bytes(Arc::clone(&tile_reference)).await {
-                Ok(tile) => return Ok(tile),
+            let result = match self.load_tile_bytes(Arc::clone(&tile_reference)).await {
+                Ok(tile) => process(tile).await,
+                Err(cause) => Err(cause),
+            };
+            match result {
+                Ok(processed) => return Ok(processed),
                 Err(cause) => {
                     if failures >= self.retries {
                         return Err(TileDownloadError {

--- a/src/nypl/mod.rs
+++ b/src/nypl/mod.rs
@@ -138,6 +138,10 @@ impl TilesRect for Level {
             position: self.tile_size() * pos - delta,
         }
     }
+
+    fn has_overlapping_tiles(&self) -> bool {
+        self.metadata.overlap > 0
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]

--- a/src/output_file.rs
+++ b/src/output_file.rs
@@ -58,7 +58,7 @@ pub fn get_outname(
             }
             debug!(
                 "File {:?} already exists. Trying another file name...",
-                &path
+                path
             );
             let mut name = OsString::from(&filename);
             name.push(format!("_{i:04}."));
@@ -92,9 +92,9 @@ mod tests {
             .expect("Unable to create a temporary directory to run the tests in");
         let lock = CWD_MUTEX.lock().unwrap(); // prevents multiple threads from changing cwd at once
         let cwd = current_dir().expect("Unable to getcwd");
-        set_current_dir(&tmp).expect(&format!("Unable to cd into {:?}", &tmp));
+        set_current_dir(&tmp).expect(&format!("Unable to cd into {:?}", tmp));
         let res = f(tmp.as_ref());
-        set_current_dir(&cwd).expect(&format!("Unable to cd into {:?}", &cwd));
+        set_current_dir(&cwd).expect(&format!("Unable to cd into {:?}", cwd));
         drop(lock);
         res
     }

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -114,7 +114,7 @@ pub struct ImageWithMetadata {
 
 type MetadataResult<T> = Result<T, image::ImageError>;
 
-pub fn load_encoded_tile(bytes: Arc<Vec<u8>>) -> MetadataResult<EncodedTile> {
+pub fn load_encoded_tile(position: Vec2d, bytes: Arc<Vec<u8>>) -> MetadataResult<EncodedTile> {
     let reader = ImageReader::new(Cursor::new(bytes.as_slice())).with_guessed_format()?;
     let format = reader.format().ok_or_else(unknown_format_error)?;
     let (size, color_type) = {
@@ -123,7 +123,7 @@ pub fn load_encoded_tile(bytes: Arc<Vec<u8>>) -> MetadataResult<EncodedTile> {
     };
 
     Ok(EncodedTile {
-        position: Vec2d { x: 0, y: 0 },
+        position,
         bytes,
         format,
         size,
@@ -136,6 +136,16 @@ fn unknown_format_error() -> image::ImageError {
         image::error::ImageFormatHint::Unknown,
         image::error::UnsupportedErrorKind::Format(image::error::ImageFormatHint::Unknown),
     ))
+}
+
+pub fn load_tile_with_metadata(position: Vec2d, bytes: &[u8]) -> MetadataResult<Tile> {
+    let image_with_metadata = load_image_with_metadata(bytes)?;
+    Ok(Tile::builder()
+        .with_image(image_with_metadata.image)
+        .at_position(position)
+        .with_optional_icc_profile(image_with_metadata.icc_profile)
+        .with_optional_exif_metadata(image_with_metadata.exif_metadata)
+        .build())
 }
 
 pub fn load_image_with_metadata(bytes: &[u8]) -> MetadataResult<ImageWithMetadata> {

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,8 +1,18 @@
-use image::{DynamicImage, GenericImageView, ImageDecoder, ImageReader};
+use image::{DynamicImage, GenericImageView, ImageDecoder, ImageFormat, ImageReader};
 use log::{trace, warn};
 use std::io::Cursor;
+use std::sync::Arc;
 
 use crate::{Vec2d, display_bytes};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EncodedTile {
+    pub position: Vec2d,
+    pub bytes: Arc<Vec<u8>>,
+    pub format: ImageFormat,
+    pub size: Vec2d,
+    pub color_type: image::ColorType,
+}
 
 #[derive(Clone)]
 pub struct Tile {
@@ -99,12 +109,38 @@ pub struct ImageWithMetadata {
     pub image: DynamicImage,
     pub icc_profile: Option<Vec<u8>>,
     pub exif_metadata: Option<Vec<u8>>,
+    pub format: ImageFormat,
 }
 
-type MetadataResult = Result<ImageWithMetadata, image::ImageError>;
+type MetadataResult<T> = Result<T, image::ImageError>;
 
-pub fn load_image_with_metadata(bytes: &[u8]) -> MetadataResult {
+pub fn load_encoded_tile(bytes: Arc<Vec<u8>>) -> MetadataResult<EncodedTile> {
+    let reader = ImageReader::new(Cursor::new(bytes.as_slice())).with_guessed_format()?;
+    let format = reader.format().ok_or_else(unknown_format_error)?;
+    let (size, color_type) = {
+        let decoder = reader.into_decoder()?;
+        (decoder.dimensions().into(), decoder.color_type())
+    };
+
+    Ok(EncodedTile {
+        position: Vec2d { x: 0, y: 0 },
+        bytes,
+        format,
+        size,
+        color_type,
+    })
+}
+
+fn unknown_format_error() -> image::ImageError {
+    image::ImageError::Unsupported(image::error::UnsupportedError::from_format_and_kind(
+        image::error::ImageFormatHint::Unknown,
+        image::error::UnsupportedErrorKind::Format(image::error::ImageFormatHint::Unknown),
+    ))
+}
+
+pub fn load_image_with_metadata(bytes: &[u8]) -> MetadataResult<ImageWithMetadata> {
     let reader = ImageReader::new(Cursor::new(bytes)).with_guessed_format()?;
+    let format = reader.format().ok_or_else(unknown_format_error)?;
 
     // Try to get a decoder from the reader
     let mut decoder = reader.into_decoder()?;
@@ -133,6 +169,7 @@ pub fn load_image_with_metadata(bytes: &[u8]) -> MetadataResult {
         image,
         icc_profile,
         exif_metadata,
+        format,
     })
 }
 


### PR DESCRIPTION
## Summary

This PR changes how `.tif`/`.tiff` and `.iiif` outputs are produced, and adds an efficient tile passthrough path for TIFF.

### User impact

- **`.tif`/`.tiff` output is now a ZIF-TIFF pyramid by default.** When no level-selection flags are used (`--largest`, `--max-width`, `--max-height`, `--zoom-level`), dezoomify-rs downloads **all source pyramid levels** and writes them into a single tiled TIFF. Tiles are kept as downloaded JPEG/PNG bytes when possible, avoiding decode/re-encode and preserving source compression.
- **`.iiif` output also defaults to full source-pyramid export** under the same conditions, writing each source level directly instead of re-tiling a single chosen level.
- **Single-level behavior is unchanged** when `--largest` or explicit level constraints are provided: one level is chosen and encoded as before (PNG/JPEG/etc.).
- **Faster TIFF exports for compatible sources** (JPEG/PNG tiles, grid-aligned positions, no alpha): tiles flow from network → ZIF writer without full decode.
- **Fallback remains available**: unsupported tile formats/colors or misaligned tiles trigger decode and the existing canvas TIFF path.

### Architectural changes

- **Download pipeline split**: `TileDownloader` now returns raw `DownloadedTile` bytes; decode vs passthrough is decided downstream based on output encoder capabilities.
- **Encoder trait extended** with `begin_level(SourceLevel)` and `add_encoded_tile(EncodedTile)`; default implementations reject passthrough.
- **New `ZifTiffEncoder`** (`zif-tiff` crate): writes pyramid levels via `put_tile_at_level`, validates codec/color/grid consistency, tracks occupied tile slots.
- **`TileBuffer` orchestrates multi-level output** via `BeginLevel` messages and separate decoded/encoded buffers.
- **`dezoomify_source_pyramid`** in `lib.rs`: sorts levels largest-first, computes scale factors, iterates levels through a shared canvas/encoder.
- **`TileProvider::tile_size_hint()`** added so encoders can declare expected tile grid dimensions.
- **`IiifEncoder` direct-write path**: source levels saved at native scale via `save_tile_at_scale` instead of always going through the retiler.

## Test plan

- [x] `cargo test` — 179 unit + 8 integration tests pass locally
- [x] CI green on ubuntu, macOS, windows
- [x] `ZifTiffEncoder` unit test verifies byte-identical tile passthrough
- [ ] Manual end-to-end TIFF export on IIIF/DZI/Zoomify sources with multi-level pyramids
- [ ] Manual IIIF export on sources with non-512px tiles
- [ ] Verify generic/template URLs still work with `.tiff` output (see potential issues)

## Potential issues

### P2 — IIIF `info.json` advertises wrong tile size for direct pyramid export

When using the direct source-level path, tiles are written under directories named with the **actual** downloaded tile size, but `info.json` still reports the retiler default of **512×512**. Viewers request `.../512,512/...` paths that were never written, breaking `.iiif` output for sources with 256px (or other non-512) tiles.

### P2 — Source-pyramid mode requires upfront `size_hint`; breaks lazy-size dezoomers

`dezoomify_source_pyramid` calls `largest_level_size()` before any tiles are downloaded. Dezoomers that discover image size lazily (e.g. **generic** URL templates) return `size_hint: None` initially and fail immediately with `NoLevels` when output is `.tiff`/`.iiif`. Confirmed locally: same generic input succeeds to `.png` but fails to `.tiff`.

### P1 — Behavioral change: default TIFF/IIIF downloads entire pyramid

Users who previously got a single flattened level in TIFF may now download all pyramid levels (significantly more tiles/time/storage) unless they pass `--largest` or level constraints. This is implicit with no CLI flag to opt in/out beyond level-selection args.

### P3 — Encoded-tile download failures leave gaps (no empty-tile replacement)

The decoded path inserts empty placeholder tiles on failure; the encoded path drops failed tiles entirely (`process_encoded_tile_result` → `(None, false)`). Partial failures in TIFF passthrough mode may produce incomplete pyramids without visible placeholders.

### P3 — Passthrough constraints may surprise users

ZIF passthrough requires: JPEG or PNG tiles only, no alpha, uniform codec across all tiles, grid-aligned positions, no overlaps. Violations either error (after passthrough started) or fall back to full decode — potentially slow and memory-heavy for large images.

### P3 — No end-to-end integration test for ZIF-TIFF pyramid export

Coverage is limited to the encoder unit test; multi-level pyramid assembly and real dezoomer sources are untested in CI.

### P3 — `.tiff` no longer uses the canvas/strip TIFF encoder by default

Previous TIFF output went through `Canvas` + `TiffEncoder` (decoded, re-encoded). New default is ZIF-TIFF (tiled, pyramid). Some TIFF readers handle these differently; users needing a flat decoded TIFF must use `--largest` or a non-pyramid output format.