### PR TITLE
repair malformed IIIF test fixture

### DIFF
--- a/src/iiif/mod.rs
+++ b/src/iiif/mod.rs
@@ -417,20 +417,6 @@ fn parse_unknown_manifest(
 #[test]
 fn test_tiles() {
     let data = br#"{
-            .split('/')
-            .next_back()
-            .and_then(|s: &str| {
-                let s = s.trim();
-                if s.is_empty() { None } else { Some(s) }
-            })
-            .unwrap_or("IIIF Image");
-        write!(f, "{name}")
-    }
-}
-
-#[test]
-fn test_tiles() {
-    let data = br#"{
       "@context" : "http://iiif.io/api/image/2/context.json",
       "@id" : "http://www.asmilano.it/fast/iipsrv.fcgi?IIIF=/opt/divenire/files/./tifs/05/36/536765.tif",
       "protocol" : "http://iiif.io/api/image",


### PR DESCRIPTION
The `test_tiles` JSON fixture accidentally contained a fragment of Rust source and a second test declaration inside its raw string. The permissive fallback parser hid that corruption.

Remove the embedded fragment so this test exercises ordinary IIIF `info.json` parsing.

Verified with:
- `cargo test --all-targets`: 202 tests passed, both benchmarks exercised successfully
- `cargo clippy --all-targets -- -D warnings`