### PR TITLE
apply the configured connection timeout

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -326,6 +326,17 @@ fn test_parse_duration() {
 }
 
 #[test]
+fn test_connect_timeout_option() {
+    let args = Arguments::parse_from([
+        "dezoomify-rs",
+        "--connect-timeout",
+        "123ms",
+        "https://example.com/info.json",
+    ]);
+    assert_eq!(args.connect_timeout, Duration::from_millis(123));
+}
+
+#[test]
 fn test_bulk_url_reading() {
     // Test bulk mode detection
     let mut args = Arguments {

--- a/src/network.rs
+++ b/src/network.rs
@@ -197,6 +197,7 @@ pub fn client<'a, I: Iterator<Item = (&'a String, &'a String)>>(
         .referer(false)
         .pool_max_idle_per_host(args.max_idle_per_host)
         .danger_accept_invalid_certs(args.accept_invalid_certs)
+        .connect_timeout(args.connect_timeout)
         .timeout(args.timeout)
         .build()?;
     Ok(client)


### PR DESCRIPTION
`--connect-timeout` was parsed and documented but never passed to reqwest, so changing it had no effect. Apply it independently of the existing whole-request timeout and cover custom duration parsing through the actual CLI option.

Verified with:
- `cargo test --all-targets`: 203 tests passed, both benchmarks exercised successfully
- `cargo clippy --all-targets -- -D warnings`