### PR TITLE
fix: stopped dropping image titles before save

### DIFF
--- a/src/custom_yaml/mod.rs
+++ b/src/custom_yaml/mod.rs
@@ -4,9 +4,11 @@ use serde::Deserialize;
 
 use crate::TileReference;
 use crate::dezoomer::{
-    Dezoomer, DezoomerError, DezoomerInput, Images, TileFetchResult, TileProvider, Vec2d,
-    single_level,
+    Dezoomer, DezoomerError, DezoomerInput, Images, ResolvedImage, TileFetchResult, TileProvider,
+    Vec2d, single_level,
 };
+#[cfg(test)]
+use crate::dezoomer::{PageContents, test_utils::expect_single_resolved};
 use crate::network::default_headers;
 
 mod tile_set;
@@ -26,7 +28,8 @@ impl Dezoomer for CustomDezoomer {
         let contents = data.with_contents()?.contents;
         let dezoomer: CustomYamlTiles =
             serde_yaml::from_slice(contents).map_err(DezoomerError::wrap)?;
-        Ok(single_level(dezoomer).into())
+        let title = dezoomer.title.clone();
+        Ok(ResolvedImage::new(single_level(dezoomer), title).into())
     }
 }
 
@@ -90,6 +93,19 @@ fn test_can_parse_example() {
         conf.http_headers().contains_key("Referer"),
         "There should be a referer in the example"
     );
+}
+
+#[test]
+fn test_dezoomer_title_reaches_resolved_image() {
+    // regression test: title used to get dropped on the way to ResolvedImage
+    let mut dezoomer = CustomDezoomer;
+    let yaml_path = format!("{}/tiles.yaml", env!("CARGO_MANIFEST_DIR"));
+    let input = DezoomerInput {
+        uri: "http://example.com/tiles.yaml".to_string(),
+        contents: PageContents::Success(std::fs::read(yaml_path).unwrap()),
+    };
+    let image = expect_single_resolved(dezoomer.images(&input).unwrap());
+    assert_eq!(image.title(), Some("A Palace"));
 }
 
 #[test]

--- a/src/dzi/mod.rs
+++ b/src/dzi/mod.rs
@@ -7,8 +7,10 @@ use dzi_file::DziFile;
 
 use crate::dezoomer::{
     Dezoomer, DezoomerError, DezoomerInput, DezoomerInputWithContents, Images, IntoZoomLevels,
-    TileProvider, TileReference, TilesRect, Vec2d, ZoomLevel, ZoomLevels,
+    ResolvedImage, TileProvider, TileReference, TilesRect, Vec2d, ZoomLevel, ZoomLevels,
 };
+#[cfg(test)]
+use crate::dezoomer::{PageContents, test_utils::expect_single_resolved};
 use crate::json_utils::all_json;
 use regex::Regex;
 mod dzi_file;
@@ -35,7 +37,8 @@ impl Dezoomer for DziDezoomer {
         } else {
             let DezoomerInputWithContents { uri, contents } = data.with_contents()?;
             let levels = load_from_properties(uri, contents)?;
-            Ok(levels.into())
+            let title = levels.first().and_then(|level| level.title());
+            Ok(ResolvedImage::new(levels, title).into())
         }
     }
 }
@@ -184,6 +187,29 @@ fn test_panorama() {
             "http://x.fr/y/test_files/9/1_0.jpg"
         ]
     );
+}
+
+#[test]
+fn test_dezoomer_title_reaches_resolved_image() {
+    // regression test: title used to get dropped on the way to ResolvedImage
+    let mut dezoomer = DziDezoomer;
+    let input = DezoomerInput {
+        uri: "http://x.fr/y/test.dzi".to_string(),
+        contents: PageContents::Success(
+            br#"
+        <Image
+          TileSize="256"
+          Overlap="2"
+          Format="jpg"
+          >
+          <Size Width="600" Height="300"/>
+          <DisplayRects></DisplayRects>
+        </Image>"#
+                .to_vec(),
+        ),
+    };
+    let image = expect_single_resolved(dezoomer.images(&input).unwrap());
+    assert_eq!(image.title(), Some("test"));
 }
 
 #[test]

--- a/src/google_arts_and_culture/mod.rs
+++ b/src/google_arts_and_culture/mod.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use tile_info::{PageInfo, TileInfo};
 
 use crate::dezoomer::{
-    Dezoomer, DezoomerError, DezoomerInput, Images, IntoZoomLevels, PostProcessFn, TileReference,
-    TilesRect, Vec2d, ZoomLevels,
+    Dezoomer, DezoomerError, DezoomerInput, Images, IntoZoomLevels, PostProcessFn, ResolvedImage,
+    TileReference, TilesRect, Vec2d, ZoomLevels,
 };
 
 mod decryption;
@@ -92,7 +92,7 @@ impl Dezoomer for GAPDezoomer {
                         }
                     })
                     .into_zoom_levels();
-                Ok(levels.into())
+                Ok(ResolvedImage::new(levels, Some(page_info.name.clone())).into())
             }
         }
     }
@@ -240,6 +240,25 @@ mod tests {
         assert!(level.size_hint().is_some());
         let name = level.name();
         assert!(name.contains("©Designers Anonymes")); // Name extracted from test data
+    }
+
+    #[test]
+    fn test_dezoomer_title_reaches_resolved_image() {
+        // regression test: title used to get dropped on the way to ResolvedImage
+        let mut dezoomer = GAPDezoomer::default();
+
+        let input1 = DezoomerInput {
+            uri: "https://artsandculture.google.com/asset/test".to_string(),
+            contents: PageContents::Success(get_test_page_html()),
+        };
+        let tile_info_uri = expect_needs_data(dezoomer.images(&input1));
+
+        let input2 = DezoomerInput {
+            uri: tile_info_uri,
+            contents: PageContents::Success(get_test_tile_info_xml()),
+        };
+        let image = expect_single_resolved(dezoomer.images(&input2).unwrap());
+        assert!(image.title().is_some());
     }
 
     #[test]

--- a/src/zoomify/mod.rs
+++ b/src/zoomify/mod.rs
@@ -5,8 +5,10 @@ use image_properties::{ImageProperties, ZoomLevelInfo};
 
 use crate::dezoomer::{
     Dezoomer, DezoomerError, DezoomerInput, DezoomerInputWithContents, Images, IntoZoomLevels,
-    TilesRect, Vec2d, ZoomLevels,
+    ResolvedImage, TilesRect, Vec2d, ZoomLevels,
 };
+#[cfg(test)]
+use crate::dezoomer::{PageContents, test_utils::expect_single_resolved};
 
 mod image_properties;
 
@@ -24,7 +26,8 @@ impl Dezoomer for ZoomifyDezoomer {
         self.assert(data.uri.contains("/ImageProperties.xml"))?;
         let DezoomerInputWithContents { uri, contents } = data.with_contents()?;
         let levels = load_from_properties(uri, contents)?;
-        Ok(levels.into())
+        let title = levels.first().and_then(|level| level.title());
+        Ok(ResolvedImage::new(levels, title).into())
     }
 }
 
@@ -176,4 +179,20 @@ fn test_title_extraction_simple_path() {
 
     // Test fallback when no meaningful path is found
     assert_eq!(level.title(), Some("example.com".to_string()));
+}
+
+#[test]
+fn test_dezoomer_title_reaches_resolved_image() {
+    // regression test: title used to get dropped on the way to ResolvedImage
+    let mut dezoomer = ZoomifyDezoomer;
+    let input = DezoomerInput {
+        uri: "http://example.com/images/manuscript123/ImageProperties.xml".to_string(),
+        contents: PageContents::Success(
+            br#"<IMAGE_PROPERTIES WIDTH="1000" HEIGHT="1000"
+                NUMTILES="25" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#
+                .to_vec(),
+        ),
+    };
+    let image = expect_single_resolved(dezoomer.images(&input).unwrap());
+    assert_eq!(image.title(), Some("manuscript123"));
 }


### PR DESCRIPTION
Fixes a regression where dezoomers download and save with a generic filename such as "dezoomified_000X.jpg" instead of the image/artwork title.

I found that it occurred due to the migration to the images() API, the title of the dezoomer is being lost when converting to ResolvedImage, which defaults its title attribute to None. The title was displayed correctly in the level picker since it gets read from the level directly.

the fix explicitly preserves the title for all four dezoomers, as well as adds a regression test for each format so it doesn't break again (I left the tests there because while I was looking at the history, I noticed that there was another bug that got through before).