### PR TITLE
Factor common dezoomer infrastructure

### DIFF
--- a/dezoomify-core/src/bulk_text/mod.rs
+++ b/dezoomify-core/src/bulk_text/mod.rs
@@ -1,67 +1,33 @@
 //! Pure discovery for text files containing deferred image URLs.
 
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, DeferredImage, Dezoomer, DezoomerMeta, DiscoveryDiagnostic, DiscoveryError,
-    DiscoveryInput, DiscoveryStep, ImageCatalog, ResourceOutcome, ResourceRequest, StableId,
+    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryError, ImageCatalog, StableId,
+    input_resource,
 };
 
-/// Text-list dezoomer.
-pub struct BulkText {
-    uri: String,
-    requested: bool,
-}
+pub const SPEC: DezoomerSpec = DezoomerSpec::routed("bulk_text", input_resource, catalog)
+    .recognizing(is_bulk_file, "not a bulk URL-list file");
 
-impl Dezoomer for BulkText {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if !is_bulk_file(&self.uri) => Ok(DiscoveryStep::Reject(
-                DiscoveryDiagnostic::from("not a bulk URL-list file"),
-            )),
-            DiscoveryEvent::Start if !self.requested => {
-                self.requested = true;
-                Ok(DiscoveryStep::Need(ResourceRequest::new(self.uri.clone())))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => {
-                let text = std::str::from_utf8(&response.bytes).map_err(|error| {
-                    DiscoveryError::Session(format!("failed to parse bulk list as UTF-8: {error}"))
-                })?;
-                let images = parse_text_urls_with_base(text, &self.uri)?;
-                if images.is_empty() {
-                    return Err(DiscoveryError::Session(
-                        "no valid URLs found in text file".into(),
-                    ));
-                }
-                Ok(DiscoveryStep::Complete(ImageCatalog::new(
-                    images.into_iter().enumerate().map(|(index, image)| {
-                        CatalogEntry::Deferred(DeferredImage {
-                            id: StableId::new(format!("bulk:{index}")),
-                            uri: image.uri,
-                            title: Some(image.title),
-                            warnings: Vec::new(),
-                        })
-                    }),
-                )))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                Err(DiscoveryError::Session(failure.message.clone()))
-            }
-            DiscoveryEvent::Start => {
-                Err(DiscoveryError::Session("bulk session started twice".into()))
-            }
-        }
+fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
+    let text = std::str::from_utf8(bytes).map_err(|error| {
+        DiscoveryError::Session(format!("failed to parse bulk list as UTF-8: {error}"))
+    })?;
+    let images = parse_text_urls_with_base(text, uri)?;
+    if images.is_empty() {
+        return Err(DiscoveryError::Session(
+            "no valid URLs found in text file".into(),
+        ));
     }
-}
-
-impl DezoomerMeta for BulkText {
-    const NAME: &'static str = "bulk_text";
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            uri: input.uri.clone(),
-            requested: false,
-        }
-    }
+    Ok(ImageCatalog::new(images.into_iter().enumerate().map(
+        |(index, image)| {
+            CatalogEntry::Deferred(DeferredImage {
+                id: StableId::new(format!("bulk:{index}")),
+                uri: image.uri,
+                title: Some(image.title),
+                warnings: Vec::new(),
+            })
+        },
+    )))
 }
 
 fn is_bulk_file(uri: &str) -> bool {
@@ -177,25 +143,9 @@ fn title_from_uri(uri: &str, line: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::discovery::{RequestId, ResourceOutcome, ResourceResponse};
-
-    fn response(content: &str) -> ResourceOutcome {
-        ResourceOutcome::Response(ResourceResponse {
-            id: RequestId(0),
-            bytes: content.as_bytes().to_vec(),
-        })
-    }
 
     fn complete(uri: &str, content: &str) -> Result<ImageCatalog, DiscoveryError> {
-        let mut session = BulkText::start(&DiscoveryInput::from(uri));
-        assert!(matches!(
-            session.advance(DiscoveryEvent::Start)?,
-            DiscoveryStep::Need(_)
-        ));
-        match session.advance(DiscoveryEvent::Resource(&response(content)))? {
-            DiscoveryStep::Complete(catalog) => Ok(catalog),
-            _ => panic!("bulk discovery did not complete"),
-        }
+        catalog(uri, content.as_bytes())
     }
 
     #[test]

--- a/dezoomify-core/src/core/adaptive.rs
+++ b/dezoomify-core/src/core/adaptive.rs
@@ -3,9 +3,10 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use regex::{Captures, Regex};
+use regex::Regex;
 
 use crate::Vec2d;
+use crate::template::{Part, Template};
 
 use super::model::{Request, StableId, TileId, TileRole, TileSpec};
 use super::tile_plan::{Grid, GridRequests, GridTile, TileSourceError};
@@ -26,33 +27,55 @@ pub fn is_generic_template(template: &str) -> bool {
     TEMPLATE_RE.is_match(template)
 }
 
-fn render_template(template: &str, x: u32, y: u32) -> String {
-    TEMPLATE_RE
-        .replace_all(template, |caps: &Captures| {
-            let num = if caps["dimension"].eq_ignore_ascii_case("x") {
-                x
-            } else {
-                y
-            };
-            let padding = caps
-                .name("zeroes")
-                .and_then(|value| value.as_str().parse().ok())
-                .unwrap_or(0);
-            format!("{num:0padding$}")
-        })
-        .into_owned()
+#[derive(Clone, Copy, Debug)]
+enum Dimension {
+    X,
+    Y,
+}
+
+fn parse_template(input: String) -> Template<Dimension> {
+    let input = input.into_boxed_str();
+    let mut cursor = 0;
+    let mut parts = Vec::new();
+    for captures in TEMPLATE_RE.captures_iter(&input) {
+        let matched = captures.get(0).expect("a capture has a full match");
+        parts.push(Part::literal(&input[cursor..matched.start()]));
+        let dimension = if captures["dimension"].eq_ignore_ascii_case("x") {
+            Dimension::X
+        } else {
+            Dimension::Y
+        };
+        let padding = captures
+            .name("zeroes")
+            .and_then(|value| value.as_str().parse().ok())
+            .unwrap_or(0);
+        parts.push(Part::Hole(dimension, padding));
+        cursor = matched.end();
+    }
+    parts.push(Part::literal(&input[cursor..]));
+    Template(parts)
+}
+
+fn render_template(template: &Template<Dimension>, x: u32, y: u32) -> String {
+    template.render(|dimension| match dimension {
+        Dimension::X => x,
+        Dimension::Y => y,
+    })
 }
 
 #[derive(Clone, Debug)]
 pub struct DiscoverableGrid {
     level: StableId,
-    template: String,
+    template: Template<Dimension>,
 }
 
 impl DiscoverableGrid {
     #[must_use]
     pub fn new(level: StableId, template: String) -> Self {
-        Self { level, template }
+        Self {
+            level,
+            template: parse_template(template),
+        }
     }
 
     #[must_use]
@@ -122,7 +145,7 @@ impl ProbeContinuation {
 
 #[derive(Debug)]
 struct GenericRequests {
-    template: String,
+    template: Template<Dimension>,
 }
 
 impl GridRequests for GenericRequests {
@@ -363,6 +386,15 @@ impl Dichotomy2d {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn generic_template_preserves_syntax_and_padding() {
+        let template = parse_template("a/{{ X:03 }}/{{y}}/{{z}}/{{x:bad}}".into());
+        assert_eq!(
+            render_template(&template, 4, 12),
+            "a/004/12/{{z}}/{{x:bad}}"
+        );
+    }
 
     #[test]
     fn generic_resolves_to_exact_grid() {

--- a/dezoomify-core/src/core/discovery.rs
+++ b/dezoomify-core/src/core/discovery.rs
@@ -129,9 +129,8 @@ pub enum DiscoveryStep {
 
 /// One dezoomer: a pure parser state machine driven by [`DiscoveryOperation`].
 ///
-/// This replaces the former `DiscoveryProgram`/`DiscoverySession` pair. A
-/// dezoomer is boxed as `dyn Dezoomer`, so it stays object-safe; static
-/// metadata and construction live on [`DezoomerMeta`].
+/// Complex formats remain free to implement an object-safe, multi-resource
+/// state machine. Most formats use a routed [`DezoomerSpec`] instead.
 pub trait Dezoomer: Send {
     /// Advance the parser from an input or one requested resource result.
     ///
@@ -141,49 +140,102 @@ pub trait Dezoomer: Send {
     fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError>;
 }
 
-/// Static metadata and construction for a concrete [`Dezoomer`] type.
-///
-/// [`Dezoomer`] cannot carry associated consts without losing object safety,
-/// so the name, URL hints, and constructor live here instead. A format
-/// implements both traits on one struct.
-pub trait DezoomerMeta: Dezoomer + Sized {
-    /// Public name: the `--dezoomer` selector and the diagnostic label.
-    const NAME: &'static str;
-
-    /// Cheap URL fragments used only to rank auto-detection candidates.
-    ///
-    /// The authoritative accept/reject decision stays in [`Dezoomer::advance`].
-    const URL_HINTS: &'static [&'static str] = &[];
-
-    /// Build fresh, independent parser state from the input.
-    fn start(input: &DiscoveryInput) -> Self;
+#[derive(Clone, Copy, Debug)]
+enum SpecAdapter {
+    Immediate(fn(&str) -> Result<ImageCatalog, DiscoveryError>),
+    Resource {
+        request: fn(&str) -> Result<ResourceRequest, DiscoveryError>,
+        parse: fn(&str, &[u8]) -> Result<ImageCatalog, DiscoveryError>,
+    },
+    Stateful(fn(&DiscoveryInput) -> Box<dyn Dezoomer>),
 }
 
-/// Erased constructor for a concrete [`DezoomerMeta`] type.
-#[must_use]
-pub fn erase<T: DezoomerMeta + 'static>(input: &DiscoveryInput) -> Box<dyn Dezoomer> {
-    Box::new(T::start(input))
-}
-
-/// The single declaration point for a format: its name, URL hints, and
-/// constructor, all derived from a concrete [`DezoomerMeta`] type.
+/// One co-located format declaration.
 #[derive(Clone, Copy, Debug)]
 pub struct DezoomerSpec {
-    pub name: &'static str,
-    pub url_hints: &'static [&'static str],
-    pub start: fn(&DiscoveryInput) -> Box<dyn Dezoomer>,
+    name: &'static str,
+    recognize: fn(&str) -> bool,
+    rejection: &'static str,
+    prefer: fn(&str) -> bool,
+    adapter: SpecAdapter,
 }
 
 impl DezoomerSpec {
-    /// Build a spec from a concrete dezoomer type.
+    /// Declare a format which completes from its input without a resource.
     #[must_use]
-    pub const fn of<T: DezoomerMeta + 'static>() -> Self {
+    pub const fn immediate(
+        name: &'static str,
+        complete: fn(&str) -> Result<ImageCatalog, DiscoveryError>,
+    ) -> Self {
+        Self::new(name, SpecAdapter::Immediate(complete))
+    }
+
+    /// Declare a format which parses one derived resource.
+    #[must_use]
+    pub const fn routed(
+        name: &'static str,
+        request: fn(&str) -> Result<ResourceRequest, DiscoveryError>,
+        parse: fn(&str, &[u8]) -> Result<ImageCatalog, DiscoveryError>,
+    ) -> Self {
+        Self::new(name, SpecAdapter::Resource { request, parse })
+    }
+
+    /// Declare a format backed by an object-safe, multi-resource state machine.
+    #[must_use]
+    pub const fn stateful(
+        name: &'static str,
+        start: fn(&DiscoveryInput) -> Box<dyn Dezoomer>,
+    ) -> Self {
+        Self::new(name, SpecAdapter::Stateful(start))
+    }
+
+    const fn new(name: &'static str, adapter: SpecAdapter) -> Self {
         Self {
-            name: T::NAME,
-            url_hints: T::URL_HINTS,
-            start: erase::<T>,
+            name,
+            recognize: |_| true,
+            rejection: "input not recognized",
+            prefer: |_| false,
+            adapter,
         }
     }
+
+    /// Add authoritative input recognition and its rejection diagnostic.
+    #[must_use]
+    pub const fn recognizing(
+        mut self,
+        recognize: fn(&str) -> bool,
+        rejection: &'static str,
+    ) -> Self {
+        self.recognize = recognize;
+        self.rejection = rejection;
+        self
+    }
+
+    /// Prefer this format during automatic discovery when the predicate matches.
+    #[must_use]
+    pub const fn preferring(mut self, prefer: fn(&str) -> bool) -> Self {
+        self.prefer = prefer;
+        self
+    }
+
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Whether this format prefers the supplied input URI.
+    ///
+    /// Custom registry implementations can use this to apply the same ranking
+    /// policy as the built-in registry.
+    #[must_use]
+    pub fn prefers(&self, uri: &str) -> bool {
+        (self.prefer)(uri)
+    }
+}
+
+/// Request the input URI unchanged.
+pub fn input_resource(uri: &str) -> Result<ResourceRequest, DiscoveryError> {
+    Ok(ResourceRequest::new(uri))
 }
 
 impl PartialEq for DezoomerSpec {
@@ -232,6 +284,7 @@ impl fmt::Display for DiscoveryError {
 
 impl std::error::Error for DiscoveryError {}
 
+#[derive(Clone, Copy)]
 enum CandidateState {
     New,
     Waiting(RequestId),
@@ -239,13 +292,14 @@ enum CandidateState {
 }
 
 struct Candidate {
-    id: String,
-    session: Box<dyn Dezoomer>,
+    spec: DezoomerSpec,
+    session: Option<Box<dyn Dezoomer>>,
     state: CandidateState,
 }
 
 /// A pull-driven operation with no I/O or shared mutable parser state.
 pub struct DiscoveryOperation {
+    input: DiscoveryInput,
     candidates: Vec<Candidate>,
     requests: BTreeMap<RequestId, ResourceNeed>,
     request_ids: BTreeMap<Request, RequestId>,
@@ -267,14 +321,18 @@ impl DiscoveryOperation {
         let mut candidates = Vec::new();
         for spec in specs {
             candidates.push(Candidate {
-                id: spec.name.to_owned(),
-                session: (spec.start)(input),
+                spec: *spec,
+                session: match spec.adapter {
+                    SpecAdapter::Stateful(start) => Some(start(input)),
+                    SpecAdapter::Immediate(_) | SpecAdapter::Resource { .. } => None,
+                },
                 state: CandidateState::New,
             });
         }
         // Registry validation and URL ranking supply the canonical candidate
         // order. Keep it intact here; sorting again would discard URL hints.
         Self {
+            input: input.clone(),
             candidates,
             requests: BTreeMap::new(),
             request_ids: BTreeMap::new(),
@@ -408,24 +466,53 @@ impl DiscoveryOperation {
     }
 
     fn advance_candidate(&mut self, index: usize) -> Result<DiscoveryStep, DiscoveryError> {
-        let state = match self.candidates[index].state {
+        let candidate = &self.candidates[index];
+        let state = match candidate.state {
             CandidateState::New => None,
             CandidateState::Waiting(id) => Some(id),
             CandidateState::Rejected => unreachable!("rejected candidates are not driven"),
         };
-        match state {
-            None => self.candidates[index]
-                .session
-                .advance(DiscoveryEvent::Start),
-            Some(id) => {
-                let outcome = self
+
+        if state.is_none() && !(candidate.spec.recognize)(&self.input.uri) {
+            return Ok(DiscoveryStep::Reject(candidate.spec.rejection.into()));
+        }
+
+        match candidate.spec.adapter {
+            SpecAdapter::Immediate(complete) => {
+                debug_assert!(state.is_none());
+                complete(&self.input.uri).map(DiscoveryStep::Complete)
+            }
+            SpecAdapter::Resource { request, parse } => match state {
+                None => request(&self.input.uri).map(DiscoveryStep::Need),
+                Some(id) => match self
                     .outcomes
                     .get(&id)
                     .expect("ready candidate has an outcome")
-                    .clone();
-                self.candidates[index]
+                {
+                    ResourceOutcome::Response(response) => {
+                        let uri = &self.requests[&id].request.uri;
+                        parse(uri, &response.bytes).map(DiscoveryStep::Complete)
+                    }
+                    ResourceOutcome::Failure(failure) => {
+                        Err(DiscoveryError::Session(failure.message.clone()))
+                    }
+                },
+            },
+            SpecAdapter::Stateful(_) => {
+                let outcome = state.map(|id| {
+                    self.outcomes
+                        .get(&id)
+                        .expect("ready candidate has an outcome")
+                        .clone()
+                });
+                let session = self.candidates[index]
                     .session
-                    .advance(DiscoveryEvent::Resource(&outcome))
+                    .as_mut()
+                    .expect("stateful adapter has a session");
+                match outcome.as_ref() {
+                    None => session.advance(DiscoveryEvent::Start),
+                    Some(outcome) => session.advance(DiscoveryEvent::Resource(outcome)),
+                }
             }
         }
     }
@@ -456,7 +543,7 @@ impl DiscoveryOperation {
     }
 
     fn reject_candidate(&mut self, index: usize, diagnostic: DiscoveryDiagnostic) {
-        let id = self.candidates[index].id.clone();
+        let id = self.candidates[index].spec.name.to_owned();
         self.diagnostics.push((id, diagnostic));
         self.candidates[index].state = CandidateState::Rejected;
     }
@@ -486,171 +573,89 @@ impl DiscoveryOperation {
 mod tests {
     use super::*;
     use crate::core::registry::Registry;
+    use crate::core::{CatalogEntry, DeferredImage, StableId};
 
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    enum NeedResult {
-        Complete,
-        Reject,
-        Session,
-    }
-
-    /// Generates a single-request dezoomer that requests `$uri` on start and
-    /// then completes, rejects, or errors according to `$result`.
-    macro_rules! script_dezoomer {
-        ($ty:ident, $name:literal, $uri:literal, $result:path) => {
-            struct $ty {
-                started: bool,
-            }
-
-            impl Dezoomer for $ty {
-                fn advance(
-                    &mut self,
-                    event: DiscoveryEvent<'_>,
-                ) -> Result<DiscoveryStep, DiscoveryError> {
-                    match event {
-                        DiscoveryEvent::Start if $result == NeedResult::Session => {
-                            Err(DiscoveryError::Session("not my format".into()))
-                        }
-                        DiscoveryEvent::Start if !self.started => {
-                            self.started = true;
-                            Ok(DiscoveryStep::Need(ResourceRequest::new($uri)))
-                        }
-                        DiscoveryEvent::Resource(ResourceOutcome::Response(_))
-                            if $result == NeedResult::Complete =>
-                        {
-                            Ok(DiscoveryStep::Complete(ImageCatalog::default()))
-                        }
-                        DiscoveryEvent::Resource(ResourceOutcome::Response(_))
-                            if $result == NeedResult::Reject =>
-                        {
-                            Ok(DiscoveryStep::Reject("wrong metadata".into()))
-                        }
-                        DiscoveryEvent::Resource(ResourceOutcome::Failure(_)) => {
-                            Ok(DiscoveryStep::Reject("resource unavailable".into()))
-                        }
-                        DiscoveryEvent::Resource(ResourceOutcome::Response(_)) => {
-                            unreachable!("failed session never requests a resource")
-                        }
-                        DiscoveryEvent::Start => {
-                            Err(DiscoveryError::Session("unexpected test transition".into()))
-                        }
-                    }
-                }
-            }
-
-            impl DezoomerMeta for $ty {
-                const NAME: &'static str = $name;
-
-                fn start(_: &DiscoveryInput) -> Self {
-                    Self { started: false }
-                }
-            }
-        };
-    }
-
-    /// Generates a two-stage dezoomer that requests `$first`, then `$second`,
-    /// then completes.
-    macro_rules! chain_dezoomer {
-        ($ty:ident, $name:literal, $first:literal, $second:literal) => {
-            struct $ty {
-                state: u8,
-            }
-
-            impl Dezoomer for $ty {
-                fn advance(
-                    &mut self,
-                    event: DiscoveryEvent<'_>,
-                ) -> Result<DiscoveryStep, DiscoveryError> {
-                    match (self.state, event) {
-                        (0, DiscoveryEvent::Start) => {
-                            self.state = 1;
-                            Ok(DiscoveryStep::Need(ResourceRequest::new($first)))
-                        }
-                        (1, DiscoveryEvent::Resource(ResourceOutcome::Response(_))) => {
-                            self.state = 2;
-                            Ok(DiscoveryStep::Need(ResourceRequest::new($second)))
-                        }
-                        (2, DiscoveryEvent::Resource(ResourceOutcome::Response(_))) => {
-                            Ok(DiscoveryStep::Complete(ImageCatalog::default()))
-                        }
-                        _ => Ok(DiscoveryStep::Reject("unexpected".into())),
-                    }
-                }
-            }
-
-            impl DezoomerMeta for $ty {
-                const NAME: &'static str = $name;
-
-                fn start(_: &DiscoveryInput) -> Self {
-                    Self { state: 0 }
-                }
-            }
-        };
-    }
-
-    /// Generates a single-stage dezoomer that requests `$uri`, then completes.
-    macro_rules! single_dezoomer {
-        ($ty:ident, $name:literal, $uri:literal) => {
-            struct $ty {
-                requested: bool,
-            }
-
-            impl Dezoomer for $ty {
-                fn advance(
-                    &mut self,
-                    event: DiscoveryEvent<'_>,
-                ) -> Result<DiscoveryStep, DiscoveryError> {
-                    match event {
-                        DiscoveryEvent::Start if !self.requested => {
-                            self.requested = true;
-                            Ok(DiscoveryStep::Need(ResourceRequest::new($uri)))
-                        }
-                        DiscoveryEvent::Resource(ResourceOutcome::Response(_)) => {
-                            Ok(DiscoveryStep::Complete(ImageCatalog::default()))
-                        }
-                        _ => Ok(DiscoveryStep::Reject("unexpected".into())),
-                    }
-                }
-            }
-
-            impl DezoomerMeta for $ty {
-                const NAME: &'static str = $name;
-
-                fn start(_: &DiscoveryInput) -> Self {
-                    Self { requested: false }
-                }
-            }
-        };
-    }
-
-    script_dezoomer!(
-        RejectingShared,
+    const REJECTING_SHARED: DezoomerSpec = DezoomerSpec::routed(
         "rejecting",
-        "memory://shared",
-        NeedResult::Reject
+        |_| Ok(ResourceRequest::new("memory://shared")),
+        |_, _| Err(DiscoveryError::Session("wrong metadata".into())),
     );
-    script_dezoomer!(
-        AcceptingShared,
+    const ACCEPTING_SHARED: DezoomerSpec = DezoomerSpec::routed(
         "accepting",
-        "memory://shared",
-        NeedResult::Complete
+        |_| Ok(ResourceRequest::new("memory://shared")),
+        |_, _| Ok(ImageCatalog::default()),
     );
-    script_dezoomer!(Broken, "broken", "memory://unused", NeedResult::Session);
-    script_dezoomer!(Working, "working", "memory://working", NeedResult::Complete);
-    script_dezoomer!(
-        OneMetadata,
+    const BROKEN: DezoomerSpec = DezoomerSpec::immediate("broken", |_| {
+        Err(DiscoveryError::Session("not my format".into()))
+    });
+    const WORKING: DezoomerSpec = DezoomerSpec::routed(
+        "working",
+        |_| Ok(ResourceRequest::new("memory://working")),
+        |_, _| Ok(ImageCatalog::default()),
+    );
+    const ONE_META: DezoomerSpec = DezoomerSpec::routed(
         "one",
-        "memory://metadata",
-        NeedResult::Complete
+        |_| Ok(ResourceRequest::new("memory://meta")),
+        |_, _| Ok(ImageCatalog::default()),
     );
-    script_dezoomer!(OneMeta, "one", "memory://meta", NeedResult::Complete);
+    const LOW: DezoomerSpec = DezoomerSpec::routed(
+        "low",
+        |_| Ok(ResourceRequest::new("memory://low1")),
+        |_, _| Ok(ImageCatalog::default()),
+    );
+    const A: DezoomerSpec = DezoomerSpec::routed(
+        "a",
+        |_| Ok(ResourceRequest::new("memory://a")),
+        |_, _| Ok(ImageCatalog::default()),
+    );
+    const B: DezoomerSpec = DezoomerSpec::routed(
+        "b",
+        |_| Ok(ResourceRequest::new("memory://b")),
+        |_, _| Ok(ImageCatalog::default()),
+    );
+    const C: DezoomerSpec = DezoomerSpec::routed(
+        "c",
+        |_| Ok(ResourceRequest::new("memory://c")),
+        |_, _| Ok(ImageCatalog::default()),
+    );
 
-    chain_dezoomer!(HighChain, "high", "memory://high1", "memory://high2");
+    struct Chain {
+        state: u8,
+        first: &'static str,
+        second: &'static str,
+    }
 
-    single_dezoomer!(Low, "low", "memory://low1");
-    single_dezoomer!(A, "a", "memory://a");
-    single_dezoomer!(B, "b", "memory://b");
-    single_dezoomer!(C, "c", "memory://c");
+    impl Dezoomer for Chain {
+        fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
+            match (self.state, event) {
+                (0, DiscoveryEvent::Start) => {
+                    self.state = 1;
+                    Ok(DiscoveryStep::Need(ResourceRequest::new(self.first)))
+                }
+                (1, DiscoveryEvent::Resource(ResourceOutcome::Response(_))) => {
+                    self.state = 2;
+                    Ok(DiscoveryStep::Need(ResourceRequest::new(self.second)))
+                }
+                (2, DiscoveryEvent::Resource(ResourceOutcome::Response(_))) => {
+                    Ok(DiscoveryStep::Complete(ImageCatalog::default()))
+                }
+                _ => Ok(DiscoveryStep::Reject("unexpected".into())),
+            }
+        }
+    }
+
+    fn chain(first: &'static str, second: &'static str) -> Box<dyn Dezoomer> {
+        Box::new(Chain {
+            state: 0,
+            first,
+            second,
+        })
+    }
+
+    const STATEFUL_CHAIN: DezoomerSpec =
+        DezoomerSpec::stateful("chain", |_| chain("memory://metadata", "memory://tiles"));
+    const HIGH_CHAIN: DezoomerSpec =
+        DezoomerSpec::stateful("high", |_| chain("memory://high1", "memory://high2"));
 
     struct Loop(usize);
     impl Dezoomer for Loop {
@@ -674,11 +679,11 @@ mod tests {
         }
     }
 
-    impl DezoomerMeta for Loop {
-        const NAME: &'static str = "loop";
+    impl Loop {
+        const SPEC: DezoomerSpec = DezoomerSpec::stateful("loop", Self::start);
 
-        fn start(_: &DiscoveryInput) -> Self {
-            Self(0)
+        fn start(_: &DiscoveryInput) -> Box<dyn Dezoomer> {
+            Box::new(Self(0))
         }
     }
 
@@ -697,11 +702,54 @@ mod tests {
             .unwrap();
     }
 
+    fn derived_request(input: &str) -> ResourceRequest {
+        ResourceRequest::new(format!("{input}/metadata"))
+    }
+
+    fn catalog_with_context(uri: &str) -> ImageCatalog {
+        ImageCatalog::new([CatalogEntry::Deferred(DeferredImage {
+            id: StableId::new("routed:0"),
+            uri: uri.to_owned(),
+            title: None,
+            warnings: Vec::new(),
+        })])
+    }
+
+    const ROUTED: DezoomerSpec = DezoomerSpec::routed(
+        "routed",
+        |uri| Ok(derived_request(uri)),
+        |uri, _| Ok(catalog_with_context(uri)),
+    )
+    .recognizing(|uri| uri.starts_with("route:"), "not a routed input")
+    .preferring(|uri| uri.ends_with("preferred"));
+
+    #[test]
+    fn route_adapter_recognizes_derives_and_parses_with_resource_context() {
+        assert!(ROUTED.prefers("route:preferred"));
+        let mut registry = Registry::new();
+        registry.register(ROUTED);
+        let mut operation = registry.start("route:input");
+        let need = operation.missing_resources().unwrap().pop().unwrap();
+        assert_eq!(need.request.uri, "route:input/metadata");
+        provide_response(&mut operation, need.id, b"metadata");
+        let catalog = operation.finish().unwrap();
+        let [CatalogEntry::Deferred(image)] = catalog.entries() else {
+            panic!("route parser should return its deferred image")
+        };
+        assert_eq!(image.uri, need.request.uri);
+
+        let mut rejected = registry.start("other:input");
+        assert!(matches!(
+            rejected.missing_resources(),
+            Err(DiscoveryError::NoCandidateAccepted { .. })
+        ));
+    }
+
     #[test]
     fn identical_requests_are_fanned_out_to_candidates_once() {
         let mut registry = Registry::new();
-        registry.register(DezoomerSpec::of::<RejectingShared>());
-        registry.register(DezoomerSpec::of::<AcceptingShared>());
+        registry.register(REJECTING_SHARED);
+        registry.register(ACCEPTING_SHARED);
 
         let mut operation = registry.start("memory://root");
         assert_eq!(operation.missing_resources().unwrap().len(), 1);
@@ -712,8 +760,8 @@ mod tests {
     #[test]
     fn session_errors_reject_one_candidate_and_continue() {
         let mut registry = Registry::new();
-        registry.register(DezoomerSpec::of::<Broken>());
-        registry.register(DezoomerSpec::of::<Working>());
+        registry.register(BROKEN);
+        registry.register(WORKING);
 
         let mut operation = registry.start("memory://root");
         let needs = operation.missing_resources().unwrap();
@@ -725,23 +773,29 @@ mod tests {
     #[test]
     fn parser_state_is_local_to_each_operation() {
         let mut registry = Registry::new();
-        registry.register(DezoomerSpec::of::<OneMetadata>());
+        registry.register(STATEFUL_CHAIN);
         let mut first = registry.start("memory://first");
         let mut second = registry.start("memory://second");
         let first_id = first.missing_resources().unwrap()[0].id;
         let second_id = second.missing_resources().unwrap()[0].id;
         assert_eq!(first_id, second_id);
         provide_response(&mut first, first_id, b"");
-        assert!(first.is_complete());
+        assert_eq!(
+            first.next_priority_need().unwrap().unwrap().request.uri,
+            "memory://tiles"
+        );
         assert!(!second.is_complete());
-        assert_eq!(second.missing_resources().unwrap().len(), 1);
+        assert_eq!(
+            second.next_priority_need().unwrap().unwrap().request.uri,
+            "memory://metadata"
+        );
     }
 
     #[test]
     fn priority_scheduling_fetches_higher_priority_chain_first() {
         let mut registry = Registry::new();
-        registry.register(DezoomerSpec::of::<HighChain>());
-        registry.register(DezoomerSpec::of::<Low>());
+        registry.register(HIGH_CHAIN);
+        registry.register(LOW);
 
         let mut operation = registry.start("memory://root");
         let needs = operation.missing_resources().unwrap();
@@ -765,7 +819,7 @@ mod tests {
     #[test]
     fn transition_limit_is_enforced() {
         let mut registry = Registry::new();
-        registry.register(DezoomerSpec::of::<Loop>());
+        registry.register(Loop::SPEC);
         let limits = DiscoveryLimits {
             transitions: 3,
             ..Default::default()
@@ -794,9 +848,9 @@ mod tests {
     #[test]
     fn resource_limit_rejects_offending_candidate_instead_of_aborting() {
         let mut registry = Registry::new();
-        registry.register(DezoomerSpec::of::<A>());
-        registry.register(DezoomerSpec::of::<B>());
-        registry.register(DezoomerSpec::of::<C>());
+        registry.register(A);
+        registry.register(B);
+        registry.register(C);
         let limits = DiscoveryLimits {
             resources: 2,
             ..Default::default()
@@ -824,7 +878,7 @@ mod tests {
     #[test]
     fn retained_bytes_limit_is_enforced() {
         let mut registry = Registry::new();
-        registry.register(DezoomerSpec::of::<OneMeta>());
+        registry.register(ONE_META);
         let limits = DiscoveryLimits {
             retained_bytes: 10,
             ..Default::default()

--- a/dezoomify-core/src/core/mod.rs
+++ b/dezoomify-core/src/core/mod.rs
@@ -13,8 +13,8 @@ pub mod uri;
 
 pub use adaptive::{DiscoverableGrid, DiscoverableStep, ObservationResult, ProbeContinuation};
 pub use discovery::{
-    Dezoomer, DezoomerMeta, DezoomerSpec, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, ResourceOutcome, ResourceRequest,
+    Dezoomer, DezoomerSpec, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput, DiscoveryStep,
+    ResourceOutcome, ResourceRequest, input_resource,
 };
 #[cfg(test)]
 pub use discovery::{RequestId, ResourceResponse};

--- a/dezoomify-core/src/core/registry.rs
+++ b/dezoomify-core/src/core/registry.rs
@@ -6,26 +6,21 @@ use crate::{
     zoomify,
 };
 
-/// Every built-in dezoomer, in recognition order.
-///
-/// The list order *is* the priority: earlier dezoomers are tried first during
-/// auto-detection. Each entry's name and URL hints come from its
-/// [`DezoomerMeta`] implementation, so there is no separate per-format
-/// declaration to keep in sync.
+/// Every built-in dezoomer, in candidate priority order.
 const BUILTINS: &[DezoomerSpec] = &[
-    DezoomerSpec::of::<custom_yaml::Custom>(),
-    DezoomerSpec::of::<google_arts_and_culture::Gap>(),
-    DezoomerSpec::of::<zoomify::Zoomify>(),
-    DezoomerSpec::of::<iiif::Iiif>(),
-    DezoomerSpec::of::<dzi::Dzi>(),
-    DezoomerSpec::of::<generic::Generic>(),
-    DezoomerSpec::of::<krpano::Krpano>(),
-    DezoomerSpec::of::<iipimage::Iip>(),
-    DezoomerSpec::of::<nypl::Nypl>(),
-    DezoomerSpec::of::<bulk_text::BulkText>(),
+    custom_yaml::SPEC,
+    google_arts_and_culture::SPEC,
+    zoomify::SPEC,
+    iiif::SPEC,
+    dzi::SPEC,
+    generic::SPEC,
+    krpano::SPEC,
+    iipimage::SPEC,
+    nypl::SPEC,
+    bulk_text::SPEC,
 ];
 
-/// An ordered set of dezoomers to try. Registration order is recognition order.
+/// An ordered set of dezoomers to try. Earlier registrations have priority.
 #[derive(Default, Clone)]
 pub struct Registry {
     specs: Vec<DezoomerSpec>,
@@ -42,7 +37,7 @@ impl Registry {
         self.specs.push(spec);
     }
 
-    /// Start independent parser state for every registered dezoomer, in order.
+    /// Start a discovery operation with candidates in registration order.
     #[must_use]
     pub fn start(&self, input: impl Into<DiscoveryInput>) -> DiscoveryOperation {
         self.start_with_limits(input, DiscoveryLimits::default())
@@ -59,11 +54,9 @@ impl Registry {
     }
 }
 
-/// The name of the first built-in dezoomer whose URL hints match `uri`.
+/// The first built-in dezoomer which prefers `uri`.
 fn preferred_name(uri: &str) -> Option<&'static DezoomerSpec> {
-    BUILTINS
-        .iter()
-        .find(|spec| spec.url_hints.iter().any(|hint| uri.contains(hint)))
+    BUILTINS.iter().find(|spec| spec.prefers(uri))
 }
 
 /// Compose every built-in dezoomer, preferring the one whose URL hints match.
@@ -81,7 +74,7 @@ pub fn default_registry(uri: &str) -> Registry {
 pub fn registry_for(name: &str) -> Option<Registry> {
     let spec = BUILTINS
         .iter()
-        .find(|spec| spec.name.eq_ignore_ascii_case(name))
+        .find(|spec| spec.name().eq_ignore_ascii_case(name))
         .copied()?;
     let mut registry = Registry::new();
     registry.register(spec);
@@ -95,29 +88,45 @@ mod tests {
     #[test]
     fn every_builtin_name_resolves_to_a_single_program() {
         for builtin in BUILTINS {
-            let registry = registry_for(builtin.name).unwrap_or_else(|| {
-                panic!("built-in `{}` must resolve", builtin.name);
+            let registry = registry_for(builtin.name()).unwrap_or_else(|| {
+                panic!("built-in `{}` must resolve", builtin.name());
             });
             assert_eq!(registry.specs.len(), 1);
-            assert_eq!(registry.specs[0].name, builtin.name);
+            assert_eq!(registry.specs[0].name(), builtin.name());
         }
         assert!(registry_for("nope").is_none());
     }
 
     #[test]
-    fn url_hints_prefer_the_matching_program() {
-        assert_eq!(preferred_name("x/info.json").map(|s| s.name), Some("iiif"));
-        assert_eq!(preferred_name("x/unknown").map(|s| s.name), None);
+    fn route_preferences_promote_the_matching_program() {
         assert_eq!(
-            default_registry("x/info.json").specs[0].name,
+            preferred_name("x/info.json").map(DezoomerSpec::name),
+            Some("iiif")
+        );
+        assert_eq!(preferred_name("x/unknown").map(DezoomerSpec::name), None);
+        assert_eq!(
+            default_registry("x/info.json").specs[0].name(),
             "iiif",
             "the matching program must be tried first"
         );
+        assert_eq!(
+            preferred_name("server?fif=image.tif").map(DezoomerSpec::name),
+            Some("iipimage")
+        );
+        assert_eq!(preferred_name("x/TileGroup0/0-0-0.jpg"), None);
     }
 
     #[test]
     fn default_registry_without_a_hint_keeps_definition_order() {
-        assert_eq!(default_registry("x/unknown").specs[0].name, "custom");
+        assert_eq!(default_registry("x/unknown").specs[0].name(), "custom");
         let _ = default_registry("x/unknown").start("memory://root");
+    }
+
+    #[test]
+    fn content_driven_formats_request_even_without_a_url_match() {
+        for name in ["iiif", "deepzoom"] {
+            let mut operation = registry_for(name).unwrap().start("memory://unknown");
+            assert_eq!(operation.missing_resources().unwrap().len(), 1, "{name}");
+        }
     }
 }

--- a/dezoomify-core/src/core/tile_plan.rs
+++ b/dezoomify-core/src/core/tile_plan.rs
@@ -73,6 +73,27 @@ pub trait GridRequests: fmt::Debug + Send + Sync {
     }
 }
 
+struct ClosureRequests<F> {
+    request: F,
+    processing: ProcessingRecipe,
+}
+
+impl<F> fmt::Debug for ClosureRequests<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("request closure")
+    }
+}
+
+impl<F: Fn(GridTile) -> Request + Send + Sync> GridRequests for ClosureRequests<F> {
+    fn request(&self, tile: GridTile) -> Request {
+        (self.request)(tile)
+    }
+
+    fn processing(&self) -> ProcessingRecipe {
+        self.processing.clone()
+    }
+}
+
 #[derive(Clone)]
 pub struct Grid {
     level: StableId,
@@ -136,6 +157,43 @@ impl Grid {
             count,
             requests: Arc::new(requests),
         })
+    }
+
+    pub fn with_requests(
+        level: StableId,
+        image_size: Vec2d,
+        tile_size: Vec2d,
+        overlap: Vec2d,
+        requests: impl Fn(GridTile) -> Request + Send + Sync + 'static,
+    ) -> Result<Self, TileSourceError> {
+        Self::with_processed_requests(
+            level,
+            image_size,
+            tile_size,
+            overlap,
+            ProcessingRecipe::None,
+            requests,
+        )
+    }
+
+    pub(crate) fn with_processed_requests(
+        level: StableId,
+        image_size: Vec2d,
+        tile_size: Vec2d,
+        overlap: Vec2d,
+        processing: ProcessingRecipe,
+        requests: impl Fn(GridTile) -> Request + Send + Sync + 'static,
+    ) -> Result<Self, TileSourceError> {
+        Self::new(
+            level,
+            image_size,
+            tile_size,
+            overlap,
+            ClosureRequests {
+                request: requests,
+                processing,
+            },
+        )
     }
 
     #[must_use]

--- a/dezoomify-core/src/custom_yaml/mod.rs
+++ b/dezoomify-core/src/custom_yaml/mod.rs
@@ -5,56 +5,19 @@ use std::collections::{BTreeMap, HashMap};
 use serde::Deserialize;
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerMeta, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, ImageCatalog, ImageDescriptor, LevelDescriptor, Positioned, ProcessingRecipe,
-    Request, ResourceOutcome, ResourceRequest, StableId, TileSourceError,
+    CatalogEntry, DezoomerSpec, DiscoveryError, ImageCatalog, ImageDescriptor, LevelDescriptor,
+    Positioned, ProcessingRecipe, Request, StableId, TileSourceError, input_resource,
 };
 use crate::default_headers;
 
 mod tile_set;
 mod variable;
 
-/// Explicit YAML layout dezoomer.
-pub struct Custom {
-    uri: String,
-    requested: bool,
-}
-
-impl Dezoomer for Custom {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if !self.uri.ends_with("tiles.yaml") => Ok(
-                DiscoveryStep::Reject(DiscoveryDiagnostic::from("not a tiles.yaml file")),
-            ),
-            DiscoveryEvent::Start if !self.requested => {
-                self.requested = true;
-                Ok(DiscoveryStep::Need(ResourceRequest::new(self.uri.clone())))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => {
-                catalog_from_yaml(&response.bytes).map(DiscoveryStep::Complete)
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                Err(DiscoveryError::Session(failure.message.clone()))
-            }
-            DiscoveryEvent::Start => Err(DiscoveryError::Session(
-                "custom YAML session started twice".into(),
-            )),
-        }
-    }
-}
-
-impl DezoomerMeta for Custom {
-    const NAME: &'static str = "custom";
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            uri: input.uri.clone(),
-            requested: false,
-        }
-    }
-}
+pub const SPEC: DezoomerSpec = DezoomerSpec::routed("custom", input_resource, |_, bytes| {
+    catalog_from_yaml(bytes)
+})
+.recognizing(|uri| uri.ends_with("tiles.yaml"), "not a tiles.yaml file");
 
 #[derive(Deserialize)]
 struct CustomYamlTiles {

--- a/dezoomify-core/src/custom_yaml/tile_set.rs
+++ b/dezoomify-core/src/custom_yaml/tile_set.rs
@@ -9,6 +9,7 @@ use custom_error::custom_error;
 use evalexpr::DefaultNumericTypes;
 
 use crate::Vec2d;
+use crate::template::{Part, Template};
 
 use super::variable::{BadVariableError, Variables};
 
@@ -139,16 +140,14 @@ impl<'de> Deserialize<'de> for IntTemplate {
 }
 
 #[derive(Clone, Debug)]
-struct UrlTemplate {
-    parts: Vec<UrlPart>,
-}
+struct UrlTemplate(Template<StrTemplate>);
 
 impl UrlTemplate {
     fn eval<C: evalexpr::Context<NumericTypes = DefaultNumericTypes>>(
         &self,
         context: &C,
     ) -> Result<String, UrlTemplateError> {
-        self.parts.iter().map(|p| p.eval(context)).collect()
+        self.0.try_render(|expression| expression.eval(context))
     }
 }
 
@@ -162,18 +161,18 @@ impl FromStr for UrlTemplate {
         let mut cursor = 0usize;
         for m in EXPR_RE.find_iter(s) {
             let prev = &s[cursor..m.start()];
-            parts.push(UrlPart::Constant(String::from(prev)));
+            parts.push(Part::literal(prev));
             let mut expression = &s[m.start() + 2..m.end() - 2];
             let mut min_width: usize = 0;
             if let Some(c) = ZERO_RE.captures(expression) {
                 expression = &expression[..expression.len() - c[0].len()];
                 min_width = c[1].parse().expect("regex matches only numbers");
             }
-            parts.push(UrlPart::expression(expression, min_width)?);
+            parts.push(Part::Hole(expression.parse()?, min_width));
             cursor = m.end();
         }
-        parts.push(UrlPart::constant(&s[cursor..]));
-        Ok(UrlTemplate { parts })
+        parts.push(Part::literal(&s[cursor..]));
+        Ok(UrlTemplate(Template(parts)))
     }
 }
 
@@ -184,43 +183,6 @@ impl<'de> Deserialize<'de> for UrlTemplate {
     {
         let s = String::deserialize(deserializer)?;
         FromStr::from_str(&s).map_err(de::Error::custom)
-    }
-}
-
-#[derive(Clone, Debug)]
-enum UrlPart {
-    Constant(String),
-    Expression {
-        expression: StrTemplate,
-        min_width: usize,
-    },
-}
-
-impl UrlPart {
-    fn constant<T: Into<String>>(s: T) -> UrlPart {
-        UrlPart::Constant(s.into())
-    }
-    fn expression(s: &str, min_width: usize) -> Result<UrlPart, UrlTemplateError> {
-        Ok(UrlPart::Expression {
-            expression: s.parse()?,
-            min_width,
-        })
-    }
-    fn eval<C: evalexpr::Context<NumericTypes = DefaultNumericTypes>>(
-        &self,
-        context: &C,
-    ) -> Result<String, UrlTemplateError> {
-        match self {
-            UrlPart::Constant(s) => Ok(s.clone()),
-            UrlPart::Expression {
-                expression,
-                min_width,
-            } => Ok(format!(
-                "{:0>width$}",
-                expression.eval(context)?,
-                width = min_width
-            )),
-        }
     }
 }
 

--- a/dezoomify-core/src/dzi/mod.rs
+++ b/dezoomify-core/src/dzi/mod.rs
@@ -6,63 +6,26 @@ use dzi_file::DziFile;
 use regex::Regex;
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerMeta, DiscoveryError, DiscoveryInput, DiscoveryStep, Grid,
-    GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor, Request,
-    ResourceOutcome, ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryError, Grid, ImageCatalog, ImageDescriptor,
+    LevelDescriptor, Request, ResourceRequest, StableId,
 };
 use crate::json_utils::all_json;
 
 mod dzi_file;
 
-/// Deep Zoom Image dezoomer.
-pub struct Dzi {
-    input: String,
-    requested: bool,
-    metadata_uri: Option<String>,
-}
+pub const SPEC: DezoomerSpec =
+    DezoomerSpec::routed("deepzoom", |uri| Ok(metadata_request(uri)), load_catalog)
+        .preferring(|uri| uri.contains(".dzi") || uri.contains("_files/"));
 
-impl Dezoomer for Dzi {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if !self.requested => {
-                self.requested = true;
-                let tile = Regex::new("_files/\\d+/\\d+_\\d+\\.(jpe?g|png)$")
-                    .expect("constant DZI tile pattern");
-                let uri = tile.find(&self.input).map_or_else(
-                    || self.input.clone(),
-                    |matched| format!("{}.dzi", &self.input[..matched.start()]),
-                );
-                self.metadata_uri = Some(uri.clone());
-                Ok(DiscoveryStep::Need(ResourceRequest::new(uri)))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => load_catalog(
-                self.metadata_uri.as_deref().unwrap_or(&self.input),
-                &response.bytes,
-            )
-            .map(DiscoveryStep::Complete),
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                Err(DiscoveryError::Session(failure.message.clone()))
-            }
-            DiscoveryEvent::Start => {
-                Err(DiscoveryError::Session("DZI session started twice".into()))
-            }
-        }
-    }
-}
-
-impl DezoomerMeta for Dzi {
-    const NAME: &'static str = "deepzoom";
-    const URL_HINTS: &'static [&'static str] = &[".dzi", "_files/"];
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            input: input.uri.clone(),
-            requested: false,
-            metadata_uri: None,
-        }
-    }
+fn metadata_request(input: &str) -> ResourceRequest {
+    let tile =
+        Regex::new("_files/\\d+/\\d+_\\d+\\.(jpe?g|png)$").expect("constant DZI tile pattern");
+    let uri = tile.find(input).map_or_else(
+        || input.to_owned(),
+        |matched| format!("{}.dzi", &input[..matched.start()]),
+    );
+    ResourceRequest::new(uri)
 }
 
 fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
@@ -99,14 +62,19 @@ fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryErr
         .zip((0..=max_level).rev())
         .enumerate()
         .map(|(ordinal, (size, zoom))| {
-            let id = StableId::new(format!("dzi:{image_index}:{ordinal}"));
-            let level = DziLevel {
-                base_url: Arc::clone(&base_url),
-                format: image.format.clone(),
-                zoom,
-            };
-            let source = Grid::new(id, size, tile_size, Vec2d::square(image.overlap), level)
-                .map_err(|error| DiscoveryError::Session(format!("invalid DZI grid: {error}")))?;
+            let base_url = Arc::clone(&base_url);
+            let format = image.format.clone();
+            let source = Grid::with_requests(
+                format!("dzi:{image_index}:{ordinal}").into(),
+                size,
+                tile_size,
+                Vec2d::square(image.overlap),
+                move |tile| {
+                    let cell: Vec2d = tile.coord.into();
+                    Request::new(format!("{base_url}/{zoom}/{}_{}.{format}", cell.x, cell.y))
+                },
+            )
+            .map_err(|error| DiscoveryError::Session(format!("invalid DZI grid: {error}")))?;
             Ok(LevelDescriptor::new(source).with_title(Some(format!(
                 "DZI level {ordinal} ({: >5}×{: >5} pixels)",
                 size.x, size.y,
@@ -128,23 +96,6 @@ fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryErr
         }));
     }
     Ok(ImageCatalog::new(entries))
-}
-
-#[derive(Debug)]
-struct DziLevel {
-    base_url: Arc<str>,
-    format: String,
-    zoom: u32,
-}
-
-impl GridRequests for DziLevel {
-    fn request(&self, tile: GridTile) -> Request {
-        let cell: Vec2d = tile.coord.into();
-        Request::new(format!(
-            "{}/{}/{}_{}.{}",
-            self.base_url, self.zoom, cell.x, cell.y, self.format
-        ))
-    }
 }
 
 #[cfg(test)]

--- a/dezoomify-core/src/generic/mod.rs
+++ b/dezoomify-core/src/generic/mod.rs
@@ -1,58 +1,34 @@
 //! Generic URL-template discovery backed by core's executable adaptive plan.
 
 use crate::core::adaptive::is_generic_template;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerMeta, DiscoverableGrid, DiscoveryDiagnostic, DiscoveryError,
-    DiscoveryInput, DiscoveryStep, ImageCatalog, ImageDescriptor, LevelDescriptor, StableId,
+    CatalogEntry, DezoomerSpec, DiscoverableGrid, ImageCatalog, ImageDescriptor, LevelDescriptor,
+    StableId,
 };
 
-/// Generic template dezoomer.
-pub struct Generic {
-    template: String,
-    complete: bool,
+pub const SPEC: DezoomerSpec = DezoomerSpec::immediate("generic", |template| Ok(catalog(template)))
+    .recognizing(is_generic_template, "not a generic X/Y tile template")
+    .preferring(|uri| uri.contains("{{"));
+
+fn catalog(template: &str) -> ImageCatalog {
+    ImageCatalog::new([CatalogEntry::Ready(ImageDescriptor {
+        id: StableId::new("generic:image"),
+        title: Some(template.to_owned()),
+        format: StableId::new("generic"),
+        levels: vec![LevelDescriptor::new(DiscoverableGrid::new(
+            StableId::new("generic:level"),
+            template.to_owned(),
+        ))],
+        ..Default::default()
+    })])
 }
 
-impl Dezoomer for Generic {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if !is_generic_template(&self.template) => Ok(
-                DiscoveryStep::Reject(DiscoveryDiagnostic::from("not a generic X/Y tile template")),
-            ),
-            DiscoveryEvent::Start if !self.complete => {
-                self.complete = true;
-                let level_id = StableId::new("generic:level");
-                Ok(DiscoveryStep::Complete(ImageCatalog::new([
-                    CatalogEntry::Ready(ImageDescriptor {
-                        id: StableId::new("generic:image"),
-                        title: Some(self.template.clone()),
-                        format: StableId::new("generic"),
-                        levels: vec![LevelDescriptor::new(DiscoverableGrid::new(
-                            level_id,
-                            self.template.clone(),
-                        ))],
-                        ..Default::default()
-                    }),
-                ])))
-            }
-            DiscoveryEvent::Resource(_) => Err(DiscoveryError::Session(
-                "generic discovery requests no metadata".into(),
-            )),
-            DiscoveryEvent::Start => Err(DiscoveryError::Session(
-                "generic session started twice".into(),
-            )),
-        }
-    }
-}
-
-impl DezoomerMeta for Generic {
-    const NAME: &'static str = "generic";
-    const URL_HINTS: &'static [&'static str] = &["{{"];
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            template: input.uri.clone(),
-            complete: false,
-        }
-    }
+#[test]
+fn valid_template_completes_on_start_without_resources() {
+    let mut registry = crate::core::Registry::new();
+    registry.register(SPEC);
+    let mut operation = registry.start("tiles/{{X}}/{{Y}}.jpg");
+    assert!(operation.missing_resources().unwrap().is_empty());
+    assert!(operation.is_complete());
+    assert_eq!(operation.finish().unwrap().len(), 1);
 }

--- a/dezoomify-core/src/google_arts_and_culture/mod.rs
+++ b/dezoomify-core/src/google_arts_and_culture/mod.rs
@@ -3,15 +3,21 @@
 use crate::Vec2d;
 use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerMeta, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor,
-    ProcessingRecipe, Request, ResourceOutcome, ResourceRequest, StableId,
+    CatalogEntry, Dezoomer, DezoomerSpec, DiscoveryError, DiscoveryInput, DiscoveryStep, Grid,
+    ImageCatalog, ImageDescriptor, LevelDescriptor, ProcessingRecipe, Request, ResourceOutcome,
+    ResourceRequest, StableId,
 };
 use std::sync::Arc;
 use tile_info::{PageInfo, TileInfo};
 pub(crate) mod decryption;
 mod tile_info;
 mod url;
+
+pub const SPEC: DezoomerSpec = DezoomerSpec::stateful("google_arts_and_culture", start)
+    .recognizing(
+        |uri| uri.contains("artsandculture.google.com") || uri.ends_with("=g"),
+        "not a Google Arts & Culture URL",
+    );
 
 pub struct Gap {
     uri: String,
@@ -22,13 +28,6 @@ pub struct Gap {
 impl Dezoomer for Gap {
     fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
         match event {
-            DiscoveryEvent::Start
-                if !self.uri.contains("artsandculture.google.com") && !self.uri.ends_with("=g") =>
-            {
-                Ok(DiscoveryStep::Reject(DiscoveryDiagnostic::from(
-                    "not a Google Arts & Culture URL",
-                )))
-            }
             DiscoveryEvent::Start if !self.requested => {
                 self.requested = true;
                 Ok(DiscoveryStep::Need(ResourceRequest::new(self.uri.clone())))
@@ -59,16 +58,12 @@ impl Dezoomer for Gap {
     }
 }
 
-impl DezoomerMeta for Gap {
-    const NAME: &'static str = "google_arts_and_culture";
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            uri: input.uri.clone(),
-            page: None,
-            requested: false,
-        }
-    }
+fn start(input: &DiscoveryInput) -> Box<dyn Dezoomer> {
+    Box::new(Gap {
+        uri: input.uri.clone(),
+        page: None,
+        requested: false,
+    })
 }
 
 fn catalog(page: &Arc<PageInfo>, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
@@ -88,18 +83,26 @@ fn catalog(page: &Arc<PageInfo>, bytes: &[u8]) -> Result<ImageCatalog, Discovery
                 x: tile_width * level.num_tiles_x - level.empty_pels_x,
                 y: tile_height * level.num_tiles_y - level.empty_pels_y,
             };
-            let id = StableId::new(format!("gap:{z}"));
             let tile_size = Vec2d {
                 x: tile_width,
                 y: tile_height,
             };
-            let source = GapLevel {
-                z,
-                page: Arc::clone(page),
-            };
-            let source = Grid::new(id.clone(), size, tile_size, Vec2d::default(), source).map_err(
-                |error| DiscoveryError::Session(format!("invalid Google Arts grid: {error}")),
-            )?;
+            let id = StableId::new(format!("gap:{z}"));
+            let request_page = Arc::clone(page);
+            let source = Grid::with_processed_requests(
+                id,
+                size,
+                tile_size,
+                Vec2d::default(),
+                ProcessingRecipe::GoogleArtsDecrypt,
+                move |tile| {
+                    let cell: Vec2d = tile.coord.into();
+                    Request::new(url::compute_url(&request_page, cell.x, cell.y, z))
+                },
+            )
+            .map_err(|error| {
+                DiscoveryError::Session(format!("invalid Google Arts grid: {error}"))
+            })?;
             Ok(LevelDescriptor::new(source).with_title(Some(page.name.clone())))
         })
         .collect::<Result<Vec<_>, DiscoveryError>>()?;
@@ -112,21 +115,6 @@ fn catalog(page: &Arc<PageInfo>, bytes: &[u8]) -> Result<ImageCatalog, Discovery
         ..Default::default()
     })]))
 }
-#[derive(Debug)]
-struct GapLevel {
-    z: usize,
-    page: Arc<PageInfo>,
-}
-impl GridRequests for GapLevel {
-    fn request(&self, tile: GridTile) -> Request {
-        let cell: Vec2d = tile.coord.into();
-        Request::new(url::compute_url(&self.page, cell.x, cell.y, self.z))
-    }
-    fn processing(&self) -> ProcessingRecipe {
-        ProcessingRecipe::GoogleArtsDecrypt
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,7 +129,7 @@ mod tests {
 
     fn fixture_catalog() -> ImageCatalog {
         let input = DiscoveryInput::from("https://artsandculture.google.com/asset/test");
-        let mut session = Gap::start(&input);
+        let mut session = start(&input);
         session.advance(DiscoveryEvent::Start).unwrap();
         let page = response(include_bytes!(
             "../../testdata/google_arts_and_culture/page_source.html"
@@ -162,7 +150,7 @@ mod tests {
     #[test]
     fn discovers_fixture_as_five_replayable_levels() {
         let input = DiscoveryInput::from("https://artsandculture.google.com/asset/test");
-        let mut session = Gap::start(&input);
+        let mut session = start(&input);
         let DiscoveryStep::Need(page) = session.advance(DiscoveryEvent::Start).unwrap() else {
             panic!("Google Arts discovery must request the page");
         };
@@ -220,11 +208,12 @@ mod tests {
 
     #[test]
     fn rejects_non_google_urls_without_requesting_data() {
-        let input = DiscoveryInput::from("https://example.com/test");
-        let mut session = Gap::start(&input);
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://example.com/test");
         assert!(matches!(
-            session.advance(DiscoveryEvent::Start).unwrap(),
-            DiscoveryStep::Reject(_)
+            operation.missing_resources(),
+            Err(DiscoveryError::NoCandidateAccepted { .. })
         ));
     }
 
@@ -260,7 +249,7 @@ mod tests {
     #[test]
     fn invalid_tile_information_is_reported_as_a_session_error() {
         let input = DiscoveryInput::from("https://artsandculture.google.com/asset/test");
-        let mut session = Gap::start(&input);
+        let mut session = start(&input);
         session.advance(DiscoveryEvent::Start).unwrap();
         let page = response(include_bytes!(
             "../../testdata/google_arts_and_culture/page_source.html"

--- a/dezoomify-core/src/iiif/mod.rs
+++ b/dezoomify-core/src/iiif/mod.rs
@@ -4,11 +4,9 @@ use custom_error::custom_error;
 use tile_info::ImageInfo;
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, DeferredImage, Dezoomer, DezoomerMeta, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor,
-    Request, ResourceOutcome, ResourceRequest, StableId,
+    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryError, Grid, GridRequests, GridTile,
+    ImageCatalog, ImageDescriptor, LevelDescriptor, Request, StableId, input_resource,
 };
 use crate::iiif::tile_info::TileSizeFormat;
 use crate::json_utils::all_json;
@@ -19,12 +17,11 @@ pub mod tile_info;
 #[cfg(test)]
 mod title_tests;
 
-/// IIIF dezoomer.
-/// See <https://iiif.io/>
-pub struct Iiif {
-    uri: String,
-    requested: bool,
-}
+/// IIIF dezoomer. See <https://iiif.io/>.
+pub const SPEC: DezoomerSpec =
+    DezoomerSpec::routed("iiif", input_resource, catalog).preferring(|uri| {
+        uri.contains("info.json") || uri.contains("iiif") || uri.contains("manifest.json")
+    });
 
 /// Determines the best title for an image from IIIF manifest metadata
 #[must_use]
@@ -63,38 +60,6 @@ custom_error! {pub IIIFError
 impl From<IIIFError> for DiscoveryError {
     fn from(err: IIIFError) -> Self {
         Self::Session(err.to_string())
-    }
-}
-
-impl Dezoomer for Iiif {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if !self.requested => {
-                self.requested = true;
-                Ok(DiscoveryStep::Need(ResourceRequest::new(self.uri.clone())))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => {
-                catalog(&self.uri, &response.bytes).map(DiscoveryStep::Complete)
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                Err(DiscoveryError::Session(failure.message.clone()))
-            }
-            DiscoveryEvent::Start => {
-                Err(DiscoveryError::Session("IIIF session started twice".into()))
-            }
-        }
-    }
-}
-
-impl DezoomerMeta for Iiif {
-    const NAME: &'static str = "iiif";
-    const URL_HINTS: &'static [&'static str] = &["info.json", "iiif", "manifest.json"];
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            uri: input.uri.clone(),
-            requested: false,
-        }
     }
 }
 
@@ -609,28 +574,23 @@ fn tile_urls(level: &LevelDescriptor) -> Vec<String> {
 
 #[test]
 fn discovery_requests_metadata_then_returns_normalized_replayable_levels() {
-    let input = DiscoveryInput::from("https://example.com/image/info.json");
-    let mut session = Iiif::start(&input);
-    let DiscoveryStep::Need(need) = session.advance(DiscoveryEvent::Start).unwrap() else {
-        panic!("IIIF must request its metadata");
-    };
-    assert_eq!(need.request.uri, input.uri);
-
-    let response = ResourceOutcome::Response(crate::core::ResourceResponse {
-        id: crate::core::RequestId(0),
-        bytes: br#"{
+    let mut registry = crate::core::Registry::new();
+    registry.register(SPEC);
+    let mut operation = registry.start("https://example.com/image/info.json");
+    let need = operation.missing_resources().unwrap().pop().unwrap();
+    assert_eq!(need.request.uri, "https://example.com/image/info.json");
+    operation
+        .provide(crate::core::ResourceResponse {
+            id: need.id,
+            bytes: br#"{
           "type":"ImageService3", "id":"https://images.example/item",
           "width":1000, "height":1500,
           "tiles":[{"width":512,"height":512,"scaleFactors":[1,2,4]}]
         }"#
-        .to_vec(),
-    });
-    let DiscoveryStep::Complete(catalog) = session
-        .advance(DiscoveryEvent::Resource(&response))
-        .unwrap()
-    else {
-        panic!("valid info.json must complete discovery");
-    };
+            .to_vec(),
+        })
+        .unwrap();
+    let catalog = operation.finish().unwrap();
     let [CatalogEntry::Ready(image)] = catalog.entries() else {
         panic!("info.json must be ready, not deferred");
     };

--- a/dezoomify-core/src/iipimage/mod.rs
+++ b/dezoomify-core/src/iipimage/mod.rs
@@ -1,77 +1,39 @@
 //! Pure discovery for `IIPImage` metadata and tile pyramids.
 
-use regex::Regex;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerMeta, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor,
-    Request, ResourceOutcome, ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryError, Grid, ImageCatalog, ImageDescriptor,
+    LevelDescriptor, Request, ResourceRequest, StableId,
 };
-
-/// `IIPImage` dezoomer.
-pub struct Iip {
-    input: String,
-    metadata: Option<String>,
-}
 
 const META: &str = "&OBJ=Max-size&OBJ=Tile-size&OBJ=Resolution-number";
 
-impl Dezoomer for Iip {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if self.metadata.is_none() => {
-                let meta = if self.input.ends_with(META) {
-                    self.input.clone()
-                } else {
-                    if !Regex::new("(?i)\\?FIF")
-                        .expect("constant IIP pattern")
-                        .is_match(&self.input)
-                    {
-                        return Ok(DiscoveryStep::Reject(DiscoveryDiagnostic::from(
-                            "not an IIPImage URL",
-                        )));
-                    }
-                    format!(
-                        "{}{}",
-                        self.input
-                            .chars()
-                            .take_while(|character| *character != '&')
-                            .collect::<String>(),
-                        META
-                    )
-                };
-                self.metadata = Some(meta.clone());
-                Ok(DiscoveryStep::Need(ResourceRequest::new(meta)))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => catalog(
-                self.metadata.as_deref().unwrap_or(&self.input),
-                &response.bytes,
-            )
-            .map(DiscoveryStep::Complete),
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                Err(DiscoveryError::Session(failure.message.clone()))
-            }
-            DiscoveryEvent::Start => {
-                Err(DiscoveryError::Session("IIP session started twice".into()))
-            }
-        }
-    }
+pub const SPEC: DezoomerSpec =
+    DezoomerSpec::routed("iipimage", |uri| Ok(metadata_request(uri)), catalog)
+        .recognizing(is_iip, "not an IIPImage URL")
+        .preferring(|uri| uri.to_ascii_lowercase().contains("?fif"));
+
+fn is_iip(uri: &str) -> bool {
+    uri.ends_with(META) || uri.to_ascii_lowercase().contains("?fif")
 }
 
-impl DezoomerMeta for Iip {
-    const NAME: &'static str = "iipimage";
-    const URL_HINTS: &'static [&'static str] = &["?FIF"];
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            input: input.uri.clone(),
-            metadata: None,
-        }
-    }
+fn metadata_request(input: &str) -> ResourceRequest {
+    let uri = if input.ends_with(META) {
+        input.to_owned()
+    } else {
+        format!(
+            "{}{}",
+            input
+                .chars()
+                .take_while(|character| *character != '&')
+                .collect::<String>(),
+            META
+        )
+    };
+    ResourceRequest::new(uri)
 }
 
 fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
@@ -81,17 +43,13 @@ fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
         .map(|index| {
             let reverse = metadata.levels - index - 1;
             let size = metadata.size / 2_u32.pow(reverse);
-            let id = StableId::new(format!("iip:{index}"));
-            let source = IipLevel {
-                base: Arc::clone(&base),
-                index,
-            };
-            let source = Grid::new(
-                id.clone(),
+            let base = Arc::clone(&base);
+            let source = Grid::with_requests(
+                format!("iip:{index}").into(),
                 size,
                 metadata.tile_size,
                 Vec2d::default(),
-                source,
+                move |tile| Request::new(format!("{base}&JTL={index},{}", tile.row_major_ordinal)),
             )
             .map_err(|error| DiscoveryError::Session(format!("invalid IIP grid: {error}")))?;
             Ok(LevelDescriptor::new(source).with_title(Some(format!(
@@ -107,20 +65,6 @@ fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
         levels,
         ..Default::default()
     })]))
-}
-
-#[derive(Clone, Debug)]
-struct IipLevel {
-    base: Arc<str>,
-    index: u32,
-}
-impl GridRequests for IipLevel {
-    fn request(&self, tile: GridTile) -> Request {
-        Request::new(format!(
-            "{}&JTL={},{}",
-            self.base, self.index, tile.row_major_ordinal
-        ))
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -183,13 +127,8 @@ mod tests {
     #[test]
     fn lowercase_fif_urls_request_canonical_metadata() {
         let uri = "https://publications-images.artic.edu/fcgi-bin/iipsrv.fcgi?fif=osci/Renoir_11/Color_Corrected/G39094sm2.ptif&jtl=4,11";
-        let mut session = Iip::start(&DiscoveryInput::from(uri));
-        let step = session.advance(DiscoveryEvent::Start).unwrap();
-        let DiscoveryStep::Need(need) = step else {
-            panic!("IIP URL did not request metadata")
-        };
         assert_eq!(
-            need.request.uri,
+            metadata_request(uri).request.uri,
             "https://publications-images.artic.edu/fcgi-bin/iipsrv.fcgi?fif=osci/Renoir_11/Color_Corrected/G39094sm2.ptif&OBJ=Max-size&OBJ=Tile-size&OBJ=Resolution-number"
         );
     }

--- a/dezoomify-core/src/krpano/krpano_metadata.rs
+++ b/dezoomify-core/src/krpano/krpano_metadata.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Deserializer, de};
 
 use crate::Vec2d;
+use crate::template::{Part, Template, push_padded};
 
 #[derive(Debug, Deserialize, Default)]
 pub struct KrpanoMetadata {
@@ -188,14 +189,14 @@ pub struct LevelDesc {
     pub name: &'static str,
     pub size: Vec2d,
     pub tilesize: Option<Vec2d>,
-    pub url: TemplateString<TemplateVariable>,
+    pub url: Template<TemplateVariable>,
     pub level_index: usize,
 }
 
 #[derive(Deserialize, PartialEq, Eq, Debug)]
 pub struct ShapeDesc {
     #[serde(rename = "@url")]
-    url: TemplateString<TemplateVariable>,
+    url: Template<TemplateVariable>,
     #[serde(rename = "@multires")]
     multires: Option<String>,
 }
@@ -323,10 +324,7 @@ fn parse_multires(s: &str) -> impl Iterator<Item = Result<(Vec2d, Vec2d), &'stat
     })
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct TemplateString<T>(pub Vec<TemplateStringPart<T>>);
-
-impl<'de> Deserialize<'de> for TemplateString<TemplateVariable> {
+impl<'de> Deserialize<'de> for Template<TemplateVariable> {
     fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
     where
         D: Deserializer<'de>,
@@ -338,11 +336,11 @@ impl<'de> Deserialize<'de> for TemplateString<TemplateVariable> {
     }
 }
 
-impl FromStr for TemplateString<TemplateVariable> {
+impl FromStr for Template<TemplateVariable> {
     type Err = String;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        use TemplateStringPart::{Literal, Variable};
+        use Part::{Hole, Literal};
         use TemplateVariable::{LevelIndex, Side, X, Y};
         use itertools::Itertools;
         let mut chars = input.chars();
@@ -357,85 +355,61 @@ impl FromStr for TemplateString<TemplateVariable> {
             }
             let padding = 1 + chars.take_while_ref(|&c| c == '0').count();
             parts.push(match chars.next() {
-                Some('h' | 'x' | 'u' | 'c') => Variable {
-                    padding,
-                    variable: X,
-                },
-                Some('v' | 'y' | 'r') => Variable {
-                    padding,
-                    variable: Y,
-                },
-                Some('s') => Variable {
-                    padding,
-                    variable: Side,
-                },
-                Some('l') => Variable {
-                    padding,
-                    variable: LevelIndex,
-                },
+                Some('h' | 'x' | 'u' | 'c') => Hole(X, padding),
+                Some('v' | 'y' | 'r') => Hole(Y, padding),
+                Some('s') => Hole(Side, padding),
+                Some('l') => Hole(LevelIndex, padding),
                 Some('%') => Literal(Arc::from("%")),
                 Some(x) => return Err(format!("Unknown template variable '{x}' in '{input}'")),
                 None => return Err(format!("Invalid templating syntax in '{input}'")),
             });
         }
-        Ok(TemplateString(parts))
+        Ok(Template(parts))
     }
 }
 
-impl TemplateString<TemplateVariable> {
-    pub fn all_sides(
-        self,
-        level: usize,
-    ) -> impl Iterator<Item = (&'static str, TemplateString<XY>)> + 'static {
-        let has_side = self.0.iter().any(|x| match x {
-            TemplateStringPart::Variable { variable, .. } => *variable == TemplateVariable::Side,
-            TemplateStringPart::Literal(_) => false,
-        });
-        let sides = if has_side {
-            &["forward", "back", "left", "right", "up", "down"][..]
-        } else {
-            &[""]
-        };
-        sides.iter().map(move |&side| {
-            (
-                side,
-                TemplateString(
-                    self.0
-                        .iter()
-                        .map(|part| part.with_side(side, level))
-                        .collect(),
-                ),
-            )
-        })
-    }
+pub fn all_sides(
+    template: Template<TemplateVariable>,
+    level: usize,
+) -> impl Iterator<Item = (&'static str, Template<XY>)> + 'static {
+    let has_side = template
+        .0
+        .iter()
+        .any(|part| matches!(part, Part::Hole(TemplateVariable::Side, _)));
+    let sides = if has_side {
+        &["forward", "back", "left", "right", "up", "down"][..]
+    } else {
+        &[""]
+    };
+    sides.iter().map(move |&side| {
+        (
+            side,
+            Template(
+                template
+                    .0
+                    .iter()
+                    .map(|part| part.with_side(side, level))
+                    .collect(),
+            ),
+        )
+    })
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum TemplateStringPart<T> {
-    Literal(Arc<str>),
-    Variable { padding: usize, variable: T },
-}
-
-impl TemplateStringPart<TemplateVariable> {
-    fn with_side(&self, side: &'static str, level: usize) -> TemplateStringPart<XY> {
-        use TemplateStringPart::{Literal, Variable};
+impl Part<TemplateVariable> {
+    fn with_side(&self, side: &'static str, level: usize) -> Part<XY> {
+        use Part::{Hole, Literal};
         use TemplateVariable::{LevelIndex, Side, X, Y};
         match self {
             Literal(s) => Literal(Arc::clone(s)),
-            Variable { padding, variable } => {
+            Hole(variable, padding) => {
                 let padding = *padding;
                 match variable {
-                    X => Variable {
-                        padding,
-                        variable: XY::X,
-                    },
-                    Y => Variable {
-                        padding,
-                        variable: XY::Y,
-                    },
+                    X => Hole(XY::X, padding),
+                    Y => Hole(XY::Y, padding),
                     Side => Literal(Arc::from(&side[..1])),
                     LevelIndex => {
-                        let idx_str = format!("{level:0padding$}");
+                        let mut idx_str = String::new();
+                        push_padded(&mut idx_str, level, padding);
                         Literal(Arc::from(idx_str))
                     }
                 }
@@ -461,33 +435,24 @@ pub enum XY {
 #[cfg(test)]
 mod test {
     use super::KrpanoLevel::{Cube, Cylinder, Left, Mobile};
-    use super::TemplateStringPart::{Literal, Variable};
     use super::TemplateVariable::{LevelIndex, X, Y};
     use super::*;
+    use crate::template::Part::{Hole, Literal};
 
-    fn str(s: &str) -> TemplateStringPart<TemplateVariable> {
+    fn str(s: &str) -> Part<TemplateVariable> {
         Literal(Arc::from(s))
     }
 
-    fn x(padding: usize) -> TemplateStringPart<TemplateVariable> {
-        Variable {
-            padding,
-            variable: X,
-        }
+    fn x(padding: usize) -> Part<TemplateVariable> {
+        Hole(X, padding)
     }
 
-    fn y(padding: usize) -> TemplateStringPart<TemplateVariable> {
-        Variable {
-            padding,
-            variable: Y,
-        }
+    fn y(padding: usize) -> Part<TemplateVariable> {
+        Hole(Y, padding)
     }
 
-    fn lvl(padding: usize) -> TemplateStringPart<TemplateVariable> {
-        Variable {
-            padding,
-            variable: LevelIndex,
-        }
+    fn lvl(padding: usize) -> Part<TemplateVariable> {
+        Hole(LevelIndex, padding)
     }
 
     #[test]
@@ -516,7 +481,7 @@ mod test {
                         tiledimagewidth: 31646,
                         tiledimageheight: 38234,
                         shape: vec![KrpanoLevel::Cylinder(ShapeDesc {
-                            url: TemplateString(vec![
+                            url: Template(vec![
                                 str("monomane.tiles/l7/"),
                                 y(1),
                                 str("/l7_"),
@@ -581,7 +546,7 @@ mod test {
                 tiledimagewidth: 3280,
                 tiledimageheight: 3280,
                 shape: vec![Left(ShapeDesc {
-                    url: TemplateString(vec![
+                    url: Template(vec![
                         str("https://example.com/"),
                         y(4),
                         str("/"),
@@ -610,7 +575,7 @@ mod test {
         assert_eq!(
             image.into_levels().collect::<Vec<_>>(),
             vec![KrpanoLevel::Flat(ShapeDesc {
-                url: TemplateString(vec![str("https://example.com/"),]),
+                url: Template(vec![str("https://example.com/"),]),
                 multires: Some("512,768x554,1664x1202,3200x2310,6400x4618,12800x9234".to_string()),
             })]
         );
@@ -637,7 +602,7 @@ mod test {
         assert_eq!(
             images[0].image.level,
             vec![Mobile(vec![Cube(ShapeDesc {
-                url: TemplateString(vec![str("test.jpg")]),
+                url: Template(vec![str("test.jpg")]),
                 multires: None,
             })])]
         );
@@ -666,7 +631,7 @@ mod test {
                 tiledimagewidth: 7424,
                 tiledimageheight: 9590,
                 shape: vec![Cylinder(ShapeDesc {
-                    url: TemplateString(vec![
+                    url: Template(vec![
                         str("xxx/"),
                         y(2),
                         str("/l5_"),
@@ -765,7 +730,7 @@ mod test {
     #[test]
     fn test_templatestring() {
         assert_eq!(
-            Ok(TemplateString(vec![x(3), str("%"), y(2), lvl(1)])),
+            Ok(Template(vec![x(3), str("%"), y(2), lvl(1)])),
             "%00x%%%0y%l".parse()
         );
     }

--- a/dezoomify-core/src/krpano/mod.rs
+++ b/dezoomify-core/src/krpano/mod.rs
@@ -1,27 +1,31 @@
 //! Pure, resumable discovery for krpano panoramas.
 
 use std::collections::HashSet;
-use std::fmt::{self, Write as _};
+use std::fmt;
 use std::sync::{Arc, LazyLock};
 
 use itertools::Itertools;
 use regex::Regex;
 
 use krpano_decrypt::{decrypt_xml, is_encrypted_xml};
-use krpano_metadata::{KrpanoMetadata, TemplateString, TemplateStringPart, XY};
+use krpano_metadata::{KrpanoMetadata, XY, all_sides};
 use log::{debug, info, warn};
 
 use crate::Vec2d;
 use crate::core::discovery::DiscoveryEvent;
 use crate::core::resolve_relative;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerMeta, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
+    CatalogEntry, Dezoomer, DezoomerSpec, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
     DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor,
     Request, ResourceOutcome, ResourceRequest, StableId,
 };
 use crate::krpano::krpano_metadata::{ImageInfo, LevelDesc};
+use crate::template::Template;
 
 mod krpano_metadata;
+
+pub const SPEC: DezoomerSpec =
+    DezoomerSpec::stateful("krpano", start).preferring(|uri| uri.contains("tiles.xml"));
 
 /// The krpano metadata dezoomer.
 ///
@@ -68,16 +72,11 @@ impl Dezoomer for Krpano {
     }
 }
 
-impl DezoomerMeta for Krpano {
-    const NAME: &'static str = "krpano";
-    const URL_HINTS: &'static [&'static str] = &["tiles.xml"];
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            input_uri: input.uri.clone(),
-            state: SessionState::Initial,
-        }
-    }
+fn start(input: &DiscoveryInput) -> Box<dyn Dezoomer> {
+    Box::new(Krpano {
+        input_uri: input.uri.clone(),
+        state: SessionState::Initial,
+    })
 }
 
 impl Krpano {
@@ -532,7 +531,7 @@ fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryErr
                     continue;
                 };
                 let level_number = level_index + base_index as usize;
-                for (side_name, template) in template.all_sides(level_number) {
+                for (side_name, template) in all_sides(template, level_number) {
                     let ordinal = levels.len();
                     let id = StableId::new(format!(
                         "krpano:{image_index}:{source_index}:{ordinal}:{side_name}"
@@ -602,7 +601,7 @@ fn format_level_label(shape: &str, side: &str, scene: &str) -> String {
 struct KrpanoLevel {
     base_url: Arc<str>,
     base_index: u32,
-    template: TemplateString<XY>,
+    template: Template<XY>,
     label: String,
 }
 
@@ -615,25 +614,13 @@ impl fmt::Debug for KrpanoLevel {
 impl GridRequests for KrpanoLevel {
     fn request(&self, tile: GridTile) -> Request {
         let cell: Vec2d = tile.coord.into();
-        let mut relative = String::new();
-        for part in &self.template.0 {
-            match part {
-                TemplateStringPart::Literal(value) => relative += value,
-                TemplateStringPart::Variable { padding, variable } => {
-                    write!(
-                        relative,
-                        "{value:0padding$}",
-                        value = self.base_index
-                            + match variable {
-                                XY::X => cell.x,
-                                XY::Y => cell.y,
-                            },
-                        padding = *padding,
-                    )
-                    .expect("writing to String cannot fail");
+        let relative = self.template.render(|variable| {
+            self.base_index
+                + match variable {
+                    XY::X => cell.x,
+                    XY::Y => cell.y,
                 }
-            }
-        }
+        });
         Request::new(resolve_relative(&self.base_url, &relative))
     }
 }
@@ -667,7 +654,7 @@ mod tests {
 
     fn discover_single_resource(uri: &str, bytes: Vec<u8>) -> ImageCatalog {
         let input = DiscoveryInput::from(uri);
-        let mut session = Krpano::start(&input);
+        let mut session = start(&input);
         assert!(matches!(
             session.advance(DiscoveryEvent::Start).unwrap(),
             DiscoveryStep::Need(ResourceRequest { request })
@@ -980,7 +967,7 @@ mod tests {
 
     #[test]
     fn viewer_js_is_detected_before_html_embed_markers() {
-        let mut session = Krpano::start(&DiscoveryInput::from("https://example.com/krpano.js"));
+        let mut session = start(&DiscoveryInput::from("https://example.com/krpano.js"));
         let _ = session.advance(DiscoveryEvent::Start).unwrap();
         let step = session
             .advance(DiscoveryEvent::Resource(&ResourceOutcome::Response(
@@ -997,7 +984,7 @@ mod tests {
 
     #[test]
     fn old_create_pano_viewer_js_is_detected_as_viewer_js() {
-        let mut session = Krpano::start(&DiscoveryInput::from("https://example.com/viewer.js"));
+        let mut session = start(&DiscoveryInput::from("https://example.com/viewer.js"));
         let _ = session.advance(DiscoveryEvent::Start).unwrap();
         let step = session
             .advance(DiscoveryEvent::Resource(&ResourceOutcome::Response(

--- a/dezoomify-core/src/lib.rs
+++ b/dezoomify-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod vec2d;
 pub mod zoomify;
 
 mod json_utils;
+mod template;
 
 pub use vec2d::Vec2d;
 

--- a/dezoomify-core/src/nypl/mod.rs
+++ b/dezoomify-core/src/nypl/mod.rs
@@ -7,11 +7,9 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerMeta, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor,
-    Request, ResourceOutcome, ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryError, Grid, ImageCatalog, ImageDescriptor,
+    LevelDescriptor, Request, ResourceRequest, StableId,
 };
 use crate::json_utils::number_or_string;
 
@@ -19,61 +17,23 @@ const VIEW: &str = "https://digitalcollections.nypl.org/items/";
 const META: &str = "https://access.nypl.org/image.php/";
 const POSTFIX: &str = "/tiles/config.js";
 
-pub struct Nypl {
-    input: String,
-    requested: bool,
-    metadata_uri: Option<String>,
-}
+pub const SPEC: DezoomerSpec = DezoomerSpec::routed("nypl", metadata_request, catalog)
+    .recognizing(
+        |uri| uri.starts_with(VIEW) || uri.starts_with(META),
+        "not an NYPL image URL",
+    )
+    .preferring(|uri| uri.contains("digitalcollections.nypl.org"));
 
-impl Dezoomer for Nypl {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if !self.requested => {
-                self.requested = true;
-                let meta = if self.input.starts_with(VIEW) {
-                    let id = image_id(&self.input).ok_or_else(|| {
-                        DiscoveryError::Session(format!(
-                            "unable to extract NYPL image ID from {:?}",
-                            self.input
-                        ))
-                    })?;
-                    format!("{META}{id}{POSTFIX}")
-                } else if self.input.starts_with(META) {
-                    self.input.clone()
-                } else {
-                    return Ok(DiscoveryStep::Reject(DiscoveryDiagnostic::from(
-                        "not an NYPL image URL",
-                    )));
-                };
-                self.metadata_uri = Some(meta.clone());
-                Ok(DiscoveryStep::Need(ResourceRequest::new(meta)))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => catalog(
-                self.metadata_uri.as_deref().unwrap_or(&self.input),
-                &response.bytes,
-            )
-            .map(DiscoveryStep::Complete),
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                Err(DiscoveryError::Session(failure.message.clone()))
-            }
-            DiscoveryEvent::Start => {
-                Err(DiscoveryError::Session("NYPL session started twice".into()))
-            }
-        }
-    }
-}
-
-impl DezoomerMeta for Nypl {
-    const NAME: &'static str = "nypl";
-    const URL_HINTS: &'static [&'static str] = &["digitalcollections.nypl.org"];
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            input: input.uri.clone(),
-            requested: false,
-            metadata_uri: None,
-        }
-    }
+fn metadata_request(input: &str) -> Result<ResourceRequest, DiscoveryError> {
+    let uri = if input.starts_with(VIEW) {
+        let id = image_id(input).ok_or_else(|| {
+            DiscoveryError::Session(format!("unable to extract NYPL image ID from {input:?}"))
+        })?;
+        format!("{META}{id}{POSTFIX}")
+    } else {
+        input.to_owned()
+    };
+    Ok(ResourceRequest::new(uri))
 }
 
 fn image_id(uri: &str) -> Option<String> {
@@ -112,18 +72,20 @@ fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
             (size.x > 0 && size.y > 0).then_some((index, size))
         })
         .map(|(index, size)| {
-            let level_id = StableId::new(format!("nypl:{index}"));
-            let source = NyplLevel {
-                id: Arc::from(id.as_str()),
-                metadata: Arc::clone(&metadata),
-                index,
-            };
-            let source = Grid::new(
-                level_id.clone(),
+            let id: Arc<str> = Arc::from(id.as_str());
+            let format = metadata.format.clone();
+            let source = Grid::with_requests(
+                format!("nypl:{index}").into(),
                 size,
                 Vec2d::square(metadata.tile_size),
                 Vec2d::square(metadata.overlap),
-                source,
+                move |tile| {
+                    let cell: Vec2d = tile.coord.into();
+                    Request::new(format!(
+                        "{META}{id}/tiles/0/{index}/{}_{}.{format}",
+                        cell.x, cell.y
+                    ))
+                },
             )
             .map_err(|error| DiscoveryError::Session(format!("invalid NYPL grid: {error}")))?;
             Ok(LevelDescriptor::new(source).with_title(Some(format!(
@@ -139,22 +101,6 @@ fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
         levels,
         ..Default::default()
     })]))
-}
-
-#[derive(Clone, Debug)]
-struct NyplLevel {
-    id: Arc<str>,
-    metadata: Arc<Metadata>,
-    index: u32,
-}
-impl GridRequests for NyplLevel {
-    fn request(&self, tile: GridTile) -> Request {
-        let cell: Vec2d = tile.coord.into();
-        Request::new(format!(
-            "{META}{}/tiles/0/{}/{}_{}.{}",
-            self.id, self.index, cell.x, cell.y, self.metadata.format
-        ))
-    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/dezoomify-core/src/template.rs
+++ b/dezoomify-core/src/template.rs
@@ -1,0 +1,46 @@
+use std::convert::Infallible;
+use std::fmt::{Display, Write as _};
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Template<H>(pub(crate) Vec<Part<H>>);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum Part<H> {
+    Literal(Arc<str>),
+    Hole(H, usize),
+}
+
+impl<H> Part<H> {
+    pub(crate) fn literal(value: impl Into<Arc<str>>) -> Self {
+        Self::Literal(value.into())
+    }
+}
+
+impl<H> Template<H> {
+    pub(crate) fn render<D: Display>(&self, mut value: impl FnMut(&H) -> D) -> String {
+        self.try_render(|hole| Ok::<_, Infallible>(value(hole)))
+            .unwrap_or_else(|never| match never {})
+    }
+
+    pub(crate) fn try_render<D: Display, E>(
+        &self,
+        mut value: impl FnMut(&H) -> Result<D, E>,
+    ) -> Result<String, E> {
+        let mut output = String::new();
+        for part in &self.0 {
+            match part {
+                Part::Literal(literal) => output.push_str(literal),
+                Part::Hole(hole, padding) => {
+                    let value = value(hole)?;
+                    push_padded(&mut output, value, *padding);
+                }
+            }
+        }
+        Ok(output)
+    }
+}
+
+pub(crate) fn push_padded(output: &mut String, value: impl Display, padding: usize) {
+    write!(output, "{value:0>padding$}").expect("writing to String cannot fail");
+}

--- a/dezoomify-core/src/zoomify/mod.rs
+++ b/dezoomify-core/src/zoomify/mod.rs
@@ -5,57 +5,19 @@ use std::sync::Arc;
 use image_properties::ImageProperties;
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerMeta, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor,
-    Request, ResourceOutcome, ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryError, Grid, ImageCatalog, ImageDescriptor,
+    LevelDescriptor, Request, StableId, input_resource,
 };
 
 mod image_properties;
 
-/// Zoomify metadata dezoomer.
-pub struct Zoomify {
-    uri: String,
-    requested: bool,
-}
-
-impl Dezoomer for Zoomify {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if !self.uri.contains("/ImageProperties.xml") => {
-                Ok(DiscoveryStep::Reject(DiscoveryDiagnostic::from(
-                    "not a Zoomify ImageProperties.xml URL",
-                )))
-            }
-            DiscoveryEvent::Start if !self.requested => {
-                self.requested = true;
-                Ok(DiscoveryStep::Need(ResourceRequest::new(self.uri.clone())))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => {
-                load_catalog(&self.uri, &response.bytes).map(DiscoveryStep::Complete)
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                Err(DiscoveryError::Session(failure.message.clone()))
-            }
-            DiscoveryEvent::Start => Err(DiscoveryError::Session(
-                "Zoomify session started twice".into(),
-            )),
-        }
-    }
-}
-
-impl DezoomerMeta for Zoomify {
-    const NAME: &'static str = "zoomify";
-    const URL_HINTS: &'static [&'static str] = &["ImageProperties.xml", "TileGroup"];
-
-    fn start(input: &DiscoveryInput) -> Self {
-        Self {
-            uri: input.uri.clone(),
-            requested: false,
-        }
-    }
-}
+pub const SPEC: DezoomerSpec = DezoomerSpec::routed("zoomify", input_resource, load_catalog)
+    .recognizing(
+        |uri| uri.contains("/ImageProperties.xml"),
+        "not a Zoomify ImageProperties.xml URL",
+    )
+    .preferring(|uri| uri.contains("ImageProperties.xml"));
 
 fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
     let properties: ImageProperties = serde_xml_rs::from_reader(contents).map_err(|error| {
@@ -79,15 +41,22 @@ fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryErr
         .map(|(index, info)| {
             let size = info.size;
             let tile_size = info.tile_size;
-            let id = StableId::new(format!("zoomify:{index}"));
-            let level = ZoomifyLevel {
-                base_url: Arc::clone(&base_url),
-                tiles_before: info.tiles_before,
-                index,
-            };
-            let source = Grid::new(id.clone(), size, tile_size, Vec2d::default(), level).map_err(
-                |error| DiscoveryError::Session(format!("invalid Zoomify grid: {error}")),
-            )?;
+            let base_url = Arc::clone(&base_url);
+            let source = Grid::with_requests(
+                format!("zoomify:{index}").into(),
+                size,
+                tile_size,
+                Vec2d::default(),
+                move |tile| {
+                    let cell: Vec2d = tile.coord.into();
+                    let tile_group = (u64::from(info.tiles_before) + tile.row_major_ordinal) / 256;
+                    Request::new(format!(
+                        "{base_url}/TileGroup{tile_group}/{index}-{}-{}.jpg",
+                        cell.x, cell.y
+                    ))
+                },
+            )
+            .map_err(|error| DiscoveryError::Session(format!("invalid Zoomify grid: {error}")))?;
             Ok(LevelDescriptor::new(source).with_title(Some(format!(
                 "{base_name} Zoomify level {index} ({: >5}×{: >5} pixels)",
                 size.x, size.y,
@@ -107,24 +76,6 @@ fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryErr
         levels,
         warnings,
     })]))
-}
-
-#[derive(Debug)]
-struct ZoomifyLevel {
-    base_url: Arc<str>,
-    tiles_before: u32,
-    index: usize,
-}
-
-impl GridRequests for ZoomifyLevel {
-    fn request(&self, tile: GridTile) -> Request {
-        let cell: Vec2d = tile.coord.into();
-        let tile_group = (u64::from(self.tiles_before) + tile.row_major_ordinal) / 256;
-        Request::new(format!(
-            "{}/TileGroup{}/{}-{}-{}.jpg",
-            self.base_url, tile_group, self.index, cell.x, cell.y
-        ))
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- replace repeated one-resource and immediate dezoomer state machines with co-located declarative `DezoomerSpec`s
- share template storage and rendering across Generic, custom YAML, and krpano while retaining their format-specific syntaxes
- replace trivial one-use grid request types with closure-backed grids
- remove 261 lines overall while preserving custom stateful dezoomers for Google Arts & Culture and krpano

## Behavior and API changes
- this is a breaking `dezoomify-core` API change: `DezoomerMeta`, `DezoomerSpec::of`, and public spec fields are replaced by `DezoomerSpec::{immediate,routed,stateful}` and public per-format `SPEC` constants
- lowercase IIPImage `?fif` URLs now receive the same automatic-discovery priority as uppercase `?FIF`
- the ineffective Zoomify `TileGroup` hint is removed; those inputs were already rejected by the Zoomify dezoomer
- no successful CLI discovery, tile URL, geometry, header, or output behavior is intended to change

## Verification
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`