### PR TITLE
Respect custom bulk titles in output filenames

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,8 +230,8 @@ fn inherit_deferred_context(catalog: ImageCatalog, parent: &DeferredImage) -> Im
             CatalogEntry::Ready(ref mut image) => (&mut image.title, &mut image.warnings),
             CatalogEntry::Deferred(ref mut image) => (&mut image.title, &mut image.warnings),
         };
-        if title.as_deref().is_none_or(str::is_empty) {
-            *title = parent_title.map(str::to_owned);
+        if let Some(parent_title) = parent_title {
+            *title = Some(parent_title.to_owned());
         }
         warnings.splice(0..0, parent.warnings.clone());
         entry
@@ -660,14 +660,10 @@ async fn process_bulk_image(
         zoom_level.source.image_size().map_or(0, |s| s.y)
     );
 
-    let level_title = zoom_level
-        .title
-        .clone()
-        .unwrap_or_else(|| image_title.to_owned());
     let indexed_outfile = bulk_outfile.map(|path| generate_bulk_output_name(path, index));
     let save_as = get_outname(
         indexed_outfile.as_deref(),
-        Some(&level_title),
+        Some(image_title),
         base_dir,
         zoom_level.source.image_size(),
     );

--- a/tests/local_dezoomifying.rs
+++ b/tests/local_dezoomifying.rs
@@ -398,7 +398,7 @@ async fn test_bulk_mode_cli_end_to_end() -> Result<(), ZoomError> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_bulk_mode_uses_image_titles_for_iiif_manifest() {
+async fn test_bulk_mode_uses_custom_titles_for_output_naming() {
     // Get workspace root to use absolute paths
     let workspace_root = get_workspace_root();
 
@@ -414,7 +414,12 @@ async fn test_bulk_mode_uses_image_titles_for_iiif_manifest() {
 
     // Use absolute path to testdata
     let zoomify_path = workspace_root.join("testdata/zoomify/test_custom_size/ImageProperties.xml");
-    writeln!(bulk_file, "{}", zoomify_path.to_string_lossy()).unwrap();
+    writeln!(
+        bulk_file,
+        "{} Archive page 001",
+        zoomify_path.to_string_lossy()
+    )
+    .unwrap();
     drop(bulk_file);
 
     // Setup arguments for bulk processing WITHOUT specifying outfile
@@ -458,11 +463,10 @@ async fn test_bulk_mode_uses_image_titles_for_iiif_manifest() {
     let file_name_os = output_file.file_name().unwrap();
     let filename = file_name_os.to_string_lossy();
 
-    // The filename should be based on the title (test_custom_size) from the Zoomify dezoomer
-    // NOT "dezoomified"
+    // The explicit title in the bulk list must win over metadata discovered from the URL.
     assert!(
-        filename.starts_with("test_custom_size"),
-        "Expected filename to start with 'test_custom_size', got: {}",
+        filename.starts_with("Archive page 001"),
+        "Expected filename to start with 'Archive page 001', got: {}",
         filename
     );
     assert!(


### PR DESCRIPTION
Fixes #340.

Bulk-list entry titles now override titles discovered while resolving their URLs, and bulk filename generation uses that image title rather than the selected level title.

Tests: cargo test --workspace; cargo clippy --workspace --all-targets -- -D warnings