### PR TITLE
Make dezoomer discovery declarative and support Zoomify viewer pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ One workspace, two crates. Dependencies from app to core only.
 | Orchestration, image/level pickers, bulk mode | [`src/lib.rs`](src/lib.rs) |
 | Output encoders (PNG/JPEG/ZIF-TIFF/IIIF) | [`src/encoder/`](src/encoder/) |
 | Built-in format registry (names, URL hints, precedence) | [`dezoomify-core/src/core/registry.rs`](dezoomify-core/src/core/registry.rs) |
-| Discovery engine (sessions, limits, request dedup) | [`dezoomify-core/src/core/discovery.rs`](dezoomify-core/src/core/discovery.rs) |
+| Discovery engine (routes, history, limits, request dedup) | [`dezoomify-core/src/core/discovery.rs`](dezoomify-core/src/core/discovery.rs) |
 | Catalog, level and tile model | [`dezoomify-core/src/core/model.rs`](dezoomify-core/src/core/model.rs) |
 | Known-grid tile plans | [`dezoomify-core/src/core/tile_plan.rs`](dezoomify-core/src/core/tile_plan.rs) |
 | Adaptive (probe-driven) tile programs | [`dezoomify-core/src/core/adaptive.rs`](dezoomify-core/src/core/adaptive.rs) |
@@ -31,14 +31,19 @@ One workspace, two crates. Dependencies from app to core only.
 
 ## Adding a format
 
-1. Implement the [`Dezoomer`](dezoomify-core/src/core/discovery.rs) trait in
-   `dezoomify-core/src/<format>/mod.rs` (smallest example:
-   [`generic`](dezoomify-core/src/generic/mod.rs)): a `start` constructor from
-   `DiscoveryInput` plus an `advance` state machine.
+1. Declare a co-located [`DezoomerSpec`](dezoomify-core/src/core/discovery.rs).
+   Resource-based formats declare one ordered `DiscoveryRoute` table. The core
+   acquires the initial URI automatically, dispatches every acquired resource
+   through that table, and follows any `DiscoveryStep::Follow` result. Use
+   `map_url` for metadata locations derived from an input URL and `extract` for
+   ordinary `(uri, bytes) -> ImageCatalog` parsers. Multi-resource handlers
+   receive typed resources and return the next declarative action; they never
+   implement acquisition states. `immediate` is reserved for URI-only formats
+   such as generic URL templates.
 2. Fixed grids: implement `RectangularSource` and wrap it in
    `KnownTilePlan::rectangular` ([`tile_plan.rs`](dezoomify-core/src/core/tile_plan.rs)).
-3. Declare the dezoomer's name and URL hints once in a co-located
-   `DezoomerSpec` const in the same module, then list that const in `BUILTINS`
+3. Keep the dezoomer's name and URL hints in that co-located `DezoomerSpec`,
+   then list the const in `BUILTINS`
    ([`dezoomify-core/src/core/registry.rs`](dezoomify-core/src/core/registry.rs)).
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ https://artsandculture.google.com/asset/light-in-the-dark/ZQFouDGMVmsI2w
 
 ### Zoomify
 
-You can give dezoomify-rs a URL to the `ImageProperties.xml` file or to one
-of the image tiles.
+You can give dezoomify-rs the URL of a Zoomify viewer page, the
+`ImageProperties.xml` file, or one of the image tiles. Viewer-page discovery
+supports the standard `Z.showImage` and legacy `zoomifyImagePath` declarations.
 You can use [dezoomify-extension](https://lovasoa.github.io/dezoomify-extension/) to
 find the URL of this file.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ https://artsandculture.google.com/asset/light-in-the-dark/ZQFouDGMVmsI2w
 
 You can give dezoomify-rs the URL of a Zoomify viewer page, the
 `ImageProperties.xml` file, or one of the image tiles. Viewer-page discovery
-supports the standard `Z.showImage` and legacy `zoomifyImagePath` declarations.
+supports standard `Z.showImage`, legacy `zoomifyImagePath`, and OpenLayers
+`zoomifytileservice` declarations.
 You can use [dezoomify-extension](https://lovasoa.github.io/dezoomify-extension/) to
 find the URL of this file.
 

--- a/dezoomify-core/src/bulk_text/mod.rs
+++ b/dezoomify-core/src/bulk_text/mod.rs
@@ -1,12 +1,13 @@
 //! Pure discovery for text files containing deferred image URLs.
 
 use crate::core::{
-    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryError, ImageCatalog, StableId,
-    input_resource,
+    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryError, DiscoveryMatch, ImageCatalog,
+    StableId,
 };
 
-pub const SPEC: DezoomerSpec = DezoomerSpec::routed("bulk_text", input_resource, catalog)
-    .recognizing(is_bulk_file, "not a bulk URL-list file");
+pub const SPEC: DezoomerSpec =
+    DezoomerSpec::new("bulk_text", &[DiscoveryMatch::any().extract(catalog)])
+        .recognizing(is_bulk_file, "not a bulk URL-list file");
 
 fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
     let text = std::str::from_utf8(bytes).map_err(|error| {

--- a/dezoomify-core/src/bulk_text/mod.rs
+++ b/dezoomify-core/src/bulk_text/mod.rs
@@ -24,7 +24,7 @@ fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
             CatalogEntry::Deferred(DeferredImage {
                 id: StableId::new(format!("bulk:{index}")),
                 uri: image.uri,
-                title: Some(image.title),
+                title: image.title,
                 warnings: Vec::new(),
             })
         },
@@ -43,7 +43,7 @@ fn is_bulk_file(uri: &str) -> bool {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ListedImage {
     uri: String,
-    title: String,
+    title: Option<String>,
 }
 
 #[cfg(test)]
@@ -70,7 +70,7 @@ fn parse_text_urls_with_base(
             let title = parts
                 .next()
                 .filter(|title| !title.is_empty())
-                .map_or_else(|| title_from_uri(&uri, line_number), str::to_owned);
+                .map(str::to_owned);
             Ok(ListedImage { uri, title })
         })
         .collect()
@@ -125,22 +125,6 @@ fn validate_uri(input: &str, line: usize) -> Result<(), DiscoveryError> {
     )))
 }
 
-fn title_from_uri(uri: &str, line: usize) -> String {
-    url::Url::parse(uri)
-        .ok()
-        .and_then(|url| {
-            url.path_segments()?
-                .rfind(|segment| !segment.is_empty())
-                .map(str::to_owned)
-        })
-        .map(|name| {
-            name.rsplit_once('.')
-                .map_or(name.clone(), |(stem, _)| stem.to_owned())
-        })
-        .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| format!("URL_{line}"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,15 +150,15 @@ mod tests {
             vec![
                 ListedImage {
                     uri: "https://example.test/a.jpg".into(),
-                    title: "A title".into()
+                    title: Some("A title".into())
                 },
                 ListedImage {
                     uri: "./local.dzi".into(),
-                    title: "URL_3".into()
+                    title: None
                 },
                 ListedImage {
                     uri: "https://example.org/manifest.json".into(),
-                    title: "manifest".into()
+                    title: None
                 },
             ]
         );
@@ -182,17 +166,10 @@ mod tests {
             "http://example.com/image1.jpg My Custom Title\nhttps://example.org/manifest.json Another Title",
         )
         .unwrap();
-        assert_eq!(urls[0].title, "My Custom Title");
-        assert_eq!(urls[1].title, "Another Title");
+        assert_eq!(urls[0].title.as_deref(), Some("My Custom Title"));
+        assert_eq!(urls[1].title.as_deref(), Some("Another Title"));
         let error = parse_text_urls("not_a_valid_url").unwrap_err().to_string();
         assert!(error.contains("line 1") && error.contains("not_a_valid_url"));
-        assert_eq!(title_from_uri("http://example.com/image.jpg", 1), "image");
-        assert_eq!(
-            title_from_uri("https://example.org/path/manifest.json", 2),
-            "manifest"
-        );
-        assert_eq!(title_from_uri("http://example.com/", 3), "URL_3");
-        assert_eq!(title_from_uri("not_a_url", 4), "URL_4");
     }
 
     #[test]
@@ -205,7 +182,7 @@ mod tests {
         assert_eq!(catalog.len(), 2);
         let entries = catalog.into_entries();
         assert!(
-            matches!(entries[0], CatalogEntry::Deferred(DeferredImage { ref uri, ref title, .. }) if uri == "http://example.com/image1.jpg" && title.as_deref() == Some("image1"))
+            matches!(entries[0], CatalogEntry::Deferred(DeferredImage { ref uri, title: None, .. }) if uri == "http://example.com/image1.jpg")
         );
         assert!(
             matches!(entries[1], CatalogEntry::Deferred(DeferredImage { ref uri, .. }) if uri == "https://example.org/manifest.json")

--- a/dezoomify-core/src/bulk_text/mod.rs
+++ b/dezoomify-core/src/bulk_text/mod.rs
@@ -6,7 +6,7 @@ use crate::core::{
 };
 
 pub const SPEC: DezoomerSpec =
-    DezoomerSpec::new("bulk_text", &[DiscoveryMatch::any().extract(catalog)])
+    DezoomerSpec::new("bulk_text", &[DiscoveryMatch::Any.extract(catalog)])
         .recognizing(is_bulk_file, "not a bulk URL-list file");
 
 fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {

--- a/dezoomify-core/src/core/discovery.rs
+++ b/dezoomify-core/src/core/discovery.rs
@@ -4,82 +4,42 @@
 //! resource to follow next. The application owns acquisition and feeds each
 //! outcome to [`DiscoveryOperation`].
 
-use std::collections::BTreeMap;
 use std::fmt;
 
 use super::model::{ImageCatalog, Request};
 
-/// Opaque input supplied to a discovery program.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct DiscoveryInput {
-    pub uri: String,
-}
-
-impl From<String> for DiscoveryInput {
-    fn from(uri: String) -> Self {
-        Self { uri }
-    }
-}
-
-impl From<&str> for DiscoveryInput {
-    fn from(uri: &str) -> Self {
-        Self { uri: uri.into() }
-    }
-}
-
-/// A stable identifier for one requested resource in an operation.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct RequestId(pub u64);
+pub struct RequestId(pub usize);
 
-/// A resource which must be supplied by the application before discovery can
-/// continue.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResourceNeed {
     pub id: RequestId,
     pub request: Request,
 }
-
-/// Bytes supplied by the application for a request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResourceResponse {
     pub id: RequestId,
     pub bytes: Vec<u8>,
-    /// HTTP media type, when the resource provider supplied one.
-    pub content_type: Option<String>,
 }
-
 impl ResourceResponse {
     #[must_use]
     pub fn new(id: RequestId, bytes: impl Into<Vec<u8>>) -> Self {
         Self {
             id,
             bytes: bytes.into(),
-            content_type: None,
         }
     }
-
-    #[must_use]
-    pub fn with_content_type(mut self, content_type: impl Into<String>) -> Self {
-        self.content_type = Some(content_type.into());
-        self
-    }
 }
-
-/// An application-reported failure to satisfy a request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResourceFailure {
     pub id: RequestId,
     pub message: String,
 }
-
-/// The resource result visible to a waiting program.
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum ResourceOutcome {
-    Response(ResourceResponse),
+    Response(Vec<u8>),
     Failure(ResourceFailure),
 }
-
-/// Bounds for a single discovery operation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DiscoveryLimits {
     pub transitions: usize,
@@ -97,25 +57,14 @@ impl Default for DiscoveryLimits {
     }
 }
 
-/// One declarative result yielded by a discovery rule.
 pub enum DiscoveryStep {
-    /// Continue discovery with another resource described by this request.
     Follow(Request),
     Complete(ImageCatalog),
 }
-
-impl DiscoveryStep {
-    #[must_use]
-    pub fn follow(uri: impl Into<String>) -> Self {
-        Self::Follow(Request::new(uri))
-    }
-}
-
-/// One successfully acquired resource.
 #[derive(Clone, Copy, Debug)]
 pub struct DiscoveryResource<'a> {
     request: &'a Request,
-    response: &'a ResourceResponse,
+    bytes: &'a [u8],
 }
 
 impl<'a> DiscoveryResource<'a> {
@@ -123,72 +72,39 @@ impl<'a> DiscoveryResource<'a> {
     pub const fn uri(self) -> &'a str {
         self.request.uri.as_str()
     }
-
     #[must_use]
     pub fn bytes(self) -> &'a [u8] {
-        self.response.bytes.as_slice()
-    }
-
-    #[must_use]
-    pub fn content_type(self) -> Option<&'a str> {
-        self.response.content_type.as_deref()
+        self.bytes
     }
 }
-
-/// One resource acquisition failure delivered to a failure rule.
-#[derive(Clone, Copy, Debug)]
-pub struct DiscoveryFailure<'a> {
-    request: &'a Request,
-    failure: &'a ResourceFailure,
-}
-
-impl<'a> DiscoveryFailure<'a> {
-    #[must_use]
-    pub const fn uri(self) -> &'a str {
-        self.request.uri.as_str()
-    }
-
-    #[must_use]
-    pub const fn failure(self) -> &'a ResourceFailure {
-        self.failure
-    }
-}
-
-/// Read-only state supplied to a declarative route handler.
-///
-/// History is local to this candidate even when requests are deduplicated
-/// across candidates.
 pub struct DiscoveryContext<'a> {
     history_ids: &'a [RequestId],
-    requests: &'a BTreeMap<RequestId, ResourceNeed>,
-    outcomes: &'a BTreeMap<RequestId, ResourceOutcome>,
+    requests: &'a [ResourceRecord],
 }
 
 impl<'a> DiscoveryContext<'a> {
-    /// Earlier successful resources for this candidate, in discovery order.
     #[must_use]
     pub fn resources(&self) -> impl DoubleEndedIterator<Item = DiscoveryResource<'a>> + '_ {
-        self.history_ids.iter().filter_map(|id| {
-            let request = &self.requests.get(id)?.request;
-            let ResourceOutcome::Response(response) = self.outcomes.get(id)? else {
-                return None;
-            };
-            Some(DiscoveryResource { request, response })
-        })
+        self.history_ids
+            .iter()
+            .filter_map(|id| self.requests.get(id.0))
+            .filter_map(|record| match record.outcome.as_ref()? {
+                ResourceOutcome::Response(bytes) => Some(DiscoveryResource {
+                    request: &record.request,
+                    bytes,
+                }),
+                ResourceOutcome::Failure(_) => None,
+            })
     }
-
-    /// Whether this candidate already followed a resource with this URI,
-    /// regardless of whether acquisition succeeded.
     #[must_use]
     pub fn has_visited(&self, uri: &str) -> bool {
         self.history_ids.iter().any(|id| {
             self.requests
-                .get(id)
-                .is_some_and(|resource| resource.request.uri == uri)
+                .get(id.0)
+                .is_some_and(|r| r.request.uri == uri)
         })
     }
 }
-
 type RouteHandler = for<'a> fn(
     &DiscoveryContext<'a>,
     DiscoveryResource<'a>,
@@ -196,101 +112,55 @@ type RouteHandler = for<'a> fn(
 type CatalogExtractor = fn(&str, &[u8]) -> Result<ImageCatalog, DiscoveryError>;
 type FailureHandler = for<'a> fn(
     &DiscoveryContext<'a>,
-    DiscoveryFailure<'a>,
+    &'a Request,
+    &'a ResourceFailure,
 ) -> Result<DiscoveryStep, DiscoveryError>;
 type UrlMapper = fn(&str) -> Result<Request, DiscoveryError>;
 type UrlPredicate = fn(&str) -> bool;
 type ContentPredicate = fn(&[u8]) -> bool;
 
-/// A predicate for one declarative discovery route.
 #[derive(Clone, Copy, Debug)]
 pub enum DiscoveryMatch {
     Any,
     UrlSuffix(&'static str),
     UrlPredicate(UrlPredicate),
-    MediaTypes(&'static [&'static str]),
     ContentPredicate(ContentPredicate),
 }
 
 impl DiscoveryMatch {
     #[must_use]
-    pub const fn any() -> Self {
-        Self::Any
-    }
-
-    #[must_use]
-    pub const fn url_suffix(suffix: &'static str) -> Self {
-        Self::UrlSuffix(suffix)
-    }
-
-    #[must_use]
-    pub const fn url_matching(predicate: UrlPredicate) -> Self {
-        Self::UrlPredicate(predicate)
-    }
-
-    #[must_use]
-    pub const fn media_type(media_types: &'static [&'static str]) -> Self {
-        Self::MediaTypes(media_types)
-    }
-
-    #[must_use]
-    pub const fn content_matching(predicate: ContentPredicate) -> Self {
-        Self::ContentPredicate(predicate)
-    }
-
-    /// Run a multi-resource handler for a matching acquired resource.
-    #[must_use]
     pub const fn then(self, handler: RouteHandler) -> DiscoveryRoute {
-        DiscoveryRoute {
-            matcher: self,
-            handler: RouteAction::Then(handler),
-        }
+        self.route(RouteAction::Then(handler))
     }
-
-    /// Parse a matching resource directly into a catalog.
     #[must_use]
     pub const fn extract(self, extractor: CatalogExtractor) -> DiscoveryRoute {
-        DiscoveryRoute {
-            matcher: self,
-            handler: RouteAction::Extract(extractor),
-        }
+        self.route(RouteAction::Extract(extractor))
     }
-
-    /// Rewrite a matching input URI before the core acquires it.
     #[must_use]
     pub const fn map_url(self, mapper: UrlMapper) -> DiscoveryRoute {
+        self.route(RouteAction::MapUrl(mapper))
+    }
+    const fn route(self, handler: RouteAction) -> DiscoveryRoute {
         DiscoveryRoute {
             matcher: self,
-            handler: RouteAction::MapUrl(mapper),
+            handler,
         }
     }
 
-    fn matches_uri(self, uri: &str) -> bool {
-        let path = uri.split(['?', '#']).next().unwrap_or(uri);
+    fn matches(self, uri: &str, bytes: Option<&[u8]>) -> bool {
         match self {
             Self::Any => true,
-            Self::UrlSuffix(suffix) => path.ends_with(suffix),
+            Self::UrlSuffix(suffix) => uri
+                .split(['?', '#'])
+                .next()
+                .unwrap_or(uri)
+                .ends_with(suffix),
             Self::UrlPredicate(predicate) => predicate(uri),
-            Self::MediaTypes(_) | Self::ContentPredicate(_) => false,
-        }
-    }
-
-    fn matches_resource(self, resource: DiscoveryResource<'_>) -> bool {
-        match self {
-            Self::Any => true,
-            Self::UrlSuffix(_) | Self::UrlPredicate(_) => self.matches_uri(resource.uri()),
-            Self::MediaTypes(types) => resource.content_type().is_some_and(|value| {
-                let media_type = value.split(';').next().unwrap_or(value).trim();
-                types
-                    .iter()
-                    .any(|expected| media_type.eq_ignore_ascii_case(expected))
-            }),
-            Self::ContentPredicate(predicate) => predicate(resource.bytes()),
+            Self::ContentPredicate(predicate) => bytes.is_some_and(predicate),
         }
     }
 }
 
-/// An ordered declarative resource matcher and transition handler.
 #[derive(Clone, Copy, Debug)]
 pub struct DiscoveryRoute {
     matcher: DiscoveryMatch,
@@ -304,32 +174,6 @@ enum RouteAction {
     MapUrl(UrlMapper),
 }
 
-impl DiscoveryRoute {
-    fn handle(
-        self,
-        context: &DiscoveryContext<'_>,
-        resource: DiscoveryResource<'_>,
-    ) -> Option<Result<DiscoveryStep, DiscoveryError>> {
-        if !self.matcher.matches_resource(resource) {
-            return None;
-        }
-        Some(match self.handler {
-            RouteAction::Then(handler) => handler(context, resource),
-            RouteAction::Extract(extractor) => {
-                extractor(resource.uri(), resource.bytes()).map(DiscoveryStep::Complete)
-            }
-            RouteAction::MapUrl(_) => return None,
-        })
-    }
-
-    fn map_url(self, uri: &str) -> Option<Result<Request, DiscoveryError>> {
-        let RouteAction::MapUrl(mapper) = self.handler else {
-            return None;
-        };
-        self.matcher.matches_uri(uri).then(|| mapper(uri))
-    }
-}
-
 fn dispatch_resource(
     routes: &[DiscoveryRoute],
     context: &DiscoveryContext<'_>,
@@ -337,33 +181,40 @@ fn dispatch_resource(
     unmatched: &str,
 ) -> Result<DiscoveryStep, DiscoveryError> {
     for route in routes {
-        let Some(step) = route.handle(context, resource) else {
+        if !route
+            .matcher
+            .matches(resource.uri(), Some(resource.bytes()))
+        {
             continue;
+        }
+        return match route.handler {
+            RouteAction::Then(handler) => handler(context, resource),
+            RouteAction::Extract(extractor) => {
+                extractor(resource.uri(), resource.bytes()).map(DiscoveryStep::Complete)
+            }
+            RouteAction::MapUrl(_) => continue,
         };
-        return step;
     }
     Err(DiscoveryError::Session(unmatched.into()))
 }
 
-fn map_url(routes: &[DiscoveryRoute], uri: &str) -> Result<Request, DiscoveryError> {
+fn map_url(routes: &[DiscoveryRoute], request: Request) -> Result<Request, DiscoveryError> {
     for route in routes {
-        if let Some(mapped) = route.map_url(uri) {
-            return mapped;
+        if let RouteAction::MapUrl(mapper) = route.handler
+            && route.matcher.matches(&request.uri, None)
+        {
+            return mapper(&request.uri);
         }
     }
-    Ok(Request::new(uri))
+    Ok(request)
 }
 
 #[derive(Clone, Copy, Debug)]
 enum DiscoveryProgram {
     Immediate(fn(&str) -> Result<ImageCatalog, DiscoveryError>),
-    Rules {
-        routes: &'static [DiscoveryRoute],
-        on_failure: Option<FailureHandler>,
-    },
+    Rules(&'static [DiscoveryRoute], Option<FailureHandler>),
 }
 
-/// One co-located format declaration.
 #[derive(Clone, Copy, Debug)]
 pub struct DezoomerSpec {
     name: &'static str,
@@ -374,22 +225,10 @@ pub struct DezoomerSpec {
 }
 
 impl DezoomerSpec {
-    /// Declare ordered rules for resources acquired by the core.
-    ///
-    /// The core acquires the input URI automatically and dispatches every
-    /// successful resource through the same ordered rule list.
     #[must_use]
     pub const fn new(name: &'static str, routes: &'static [DiscoveryRoute]) -> Self {
-        Self::from_program(
-            name,
-            DiscoveryProgram::Rules {
-                routes,
-                on_failure: None,
-            },
-        )
+        Self::from_program(name, DiscoveryProgram::Rules(routes, None))
     }
-
-    /// Declare a format which completes from its input without a resource.
     #[must_use]
     pub const fn immediate(
         name: &'static str,
@@ -397,20 +236,14 @@ impl DezoomerSpec {
     ) -> Self {
         Self::from_program(name, DiscoveryProgram::Immediate(complete))
     }
-
-    /// Handle acquisition failures for formats with alternate resources.
     #[must_use]
     pub const fn on_failure(mut self, handler: FailureHandler) -> Self {
-        let DiscoveryProgram::Rules { routes, .. } = self.program else {
+        let DiscoveryProgram::Rules(routes, ..) = self.program else {
             panic!("an immediate dezoomer cannot handle resource failures");
         };
-        self.program = DiscoveryProgram::Rules {
-            routes,
-            on_failure: Some(handler),
-        };
+        self.program = DiscoveryProgram::Rules(routes, Some(handler));
         self
     }
-
     const fn from_program(name: &'static str, program: DiscoveryProgram) -> Self {
         Self {
             name,
@@ -420,8 +253,6 @@ impl DezoomerSpec {
             program,
         }
     }
-
-    /// Add authoritative input recognition and its rejection diagnostic.
     #[must_use]
     pub const fn recognizing(
         mut self,
@@ -432,23 +263,16 @@ impl DezoomerSpec {
         self.rejection = rejection;
         self
     }
-
-    /// Prefer this format during automatic discovery when the predicate matches.
     #[must_use]
     pub const fn preferring(mut self, prefer: fn(&str) -> bool) -> Self {
         self.prefer = prefer;
         self
     }
-
     #[must_use]
     pub const fn name(&self) -> &'static str {
         self.name
     }
 
-    /// Whether this format prefers the supplied input URI.
-    ///
-    /// Custom registry implementations can use this to apply the same ranking
-    /// policy as the built-in registry.
     #[must_use]
     pub fn prefers(&self, uri: &str) -> bool {
         (self.prefer)(uri)
@@ -461,7 +285,6 @@ impl PartialEq for DezoomerSpec {
     }
 }
 
-/// Pure discovery errors.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DiscoveryError {
     UnknownRequest(RequestId),
@@ -512,71 +335,60 @@ struct Candidate {
     history: Vec<RequestId>,
 }
 
-/// A pull-driven operation with no I/O or shared mutable parser state.
+struct ResourceRecord {
+    request: Request,
+    outcome: Option<ResourceOutcome>,
+}
+
 pub struct DiscoveryOperation {
-    input: DiscoveryInput,
+    input: String,
     candidates: Vec<Candidate>,
-    requests: BTreeMap<RequestId, ResourceNeed>,
-    request_ids: BTreeMap<Request, RequestId>,
-    outcomes: BTreeMap<RequestId, ResourceOutcome>,
+    requests: Vec<ResourceRecord>,
     diagnostics: Vec<(String, String)>,
     catalog: Option<ImageCatalog>,
-    next_request_id: u64,
     transitions: usize,
     retained_bytes: usize,
     limits: DiscoveryLimits,
 }
 
 impl DiscoveryOperation {
-    pub(crate) fn new(
-        input: &DiscoveryInput,
-        specs: &[DezoomerSpec],
-        limits: DiscoveryLimits,
-    ) -> Self {
-        let mut candidates = Vec::new();
-        for spec in specs {
-            candidates.push(Candidate {
-                spec: *spec,
+    pub(crate) fn new(input: String, specs: &[DezoomerSpec], limits: DiscoveryLimits) -> Self {
+        let candidates = specs
+            .iter()
+            .map(|&spec| Candidate {
+                spec,
                 state: CandidateState::New,
                 history: Vec::new(),
-            });
-        }
-        // Registry validation and URL ranking supply the canonical candidate
-        // order. Keep it intact here; sorting again would discard URL hints.
+            })
+            .collect();
         Self {
-            input: input.clone(),
+            input,
             candidates,
-            requests: BTreeMap::new(),
-            request_ids: BTreeMap::new(),
-            outcomes: BTreeMap::new(),
+            requests: Vec::new(),
             diagnostics: Vec::new(),
             catalog: None,
-            next_request_id: 0,
             transitions: 0,
             retained_bytes: 0,
             limits,
         }
     }
-
-    /// Return every outstanding request in stable identifier order.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a candidate cannot transition.
+    fn resource(&self, id: RequestId) -> Option<&ResourceRecord> {
+        self.requests.get(id.0)
+    }
+    fn ready(&self, state: CandidateState) -> bool {
+        matches!(state, CandidateState::New)
+            || matches!(state, CandidateState::Waiting(id) if self
+                .resource(id)
+                .is_some_and(|resource| resource.outcome.is_some()))
+    }
     pub fn missing_resources(&mut self) -> Result<Vec<ResourceNeed>, DiscoveryError> {
         self.drive()?;
-        if self.catalog.is_some() {
-            return Ok(Vec::new());
-        }
-        Ok(self.outstanding_needs().collect())
+        Ok(if self.catalog.is_none() {
+            self.outstanding_needs().collect()
+        } else {
+            Vec::new()
+        })
     }
-
-    /// Return the outstanding resource needed by the highest-priority waiting candidate.
-    ///
-    /// When candidates wait on different URIs, this picks the resource of the
-    /// first waiting candidate in registry order, preserving depth-first
-    /// priority. If no candidate is waiting, falls back to the first
-    /// outstanding request.
     pub fn next_priority_need(&mut self) -> Result<Option<ResourceNeed>, DiscoveryError> {
         self.drive()?;
         if self.catalog.is_some() {
@@ -584,60 +396,52 @@ impl DiscoveryOperation {
         }
         for candidate in &self.candidates {
             if let CandidateState::Waiting(id) = candidate.state
-                && !self.outcomes.contains_key(&id)
-                && let Some(need) = self.requests.get(&id).cloned()
+                && let Some(resource) = self.resource(id)
+                && resource.outcome.is_none()
             {
-                return Ok(Some(need));
+                return Ok(Some(ResourceNeed {
+                    id,
+                    request: resource.request.clone(),
+                }));
             }
         }
         Ok(self.outstanding_needs().next())
     }
-
-    /// Needs which have no outcome yet, in stable identifier order.
     fn outstanding_needs(&self) -> impl Iterator<Item = ResourceNeed> + '_ {
         self.requests
             .iter()
-            .filter(|(id, _)| !self.outcomes.contains_key(id))
-            .map(|(_, need)| need.clone())
+            .enumerate()
+            .filter(|(_, resource)| resource.outcome.is_none())
+            .map(|(index, resource)| ResourceNeed {
+                id: RequestId(index),
+                request: resource.request.clone(),
+            })
     }
-
-    /// Supply successfully acquired bytes.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error for an unknown or already supplied request.
     pub fn provide(&mut self, response: ResourceResponse) -> Result<(), DiscoveryError> {
-        self.provide_outcome(response.id, ResourceOutcome::Response(response))
+        self.provide_outcome(response.id, ResourceOutcome::Response(response.bytes))
     }
-
-    /// Supply a failed acquisition without imposing retry policy.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error for an unknown or already supplied request.
     pub fn provide_failure(&mut self, failure: ResourceFailure) -> Result<(), DiscoveryError> {
         self.provide_outcome(failure.id, ResourceOutcome::Failure(failure))
     }
-
     fn provide_outcome(
         &mut self,
         id: RequestId,
         outcome: ResourceOutcome,
     ) -> Result<(), DiscoveryError> {
-        if !self.requests.contains_key(&id) {
+        let Some(resource) = self.requests.get(id.0) else {
             return Err(DiscoveryError::UnknownRequest(id));
-        }
-        if self.outcomes.contains_key(&id) {
+        };
+        if resource.outcome.is_some() {
             return Err(DiscoveryError::RequestAlreadyProvided(id));
         }
-        if let ResourceOutcome::Response(response) = &outcome {
+        if let ResourceOutcome::Response(bytes) = &outcome {
             self.retained_bytes = self
                 .retained_bytes
-                .checked_add(response.bytes.len())
+                .checked_add(bytes.len())
                 .filter(|total| *total <= self.limits.retained_bytes)
                 .ok_or(DiscoveryError::MetadataSizeLimitExceeded)?;
         }
-        self.outcomes.insert(id, outcome);
+        self.requests[id.0].outcome = Some(outcome);
         self.drive()
     }
 
@@ -646,24 +450,28 @@ impl DiscoveryOperation {
         self.catalog.is_some()
     }
 
-    /// Consume this completed operation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`DiscoveryError::NotComplete`] when an application response is still needed.
     pub fn finish(mut self) -> Result<ImageCatalog, DiscoveryError> {
         self.drive()?;
         self.catalog.take().ok_or(DiscoveryError::NotComplete)
     }
-
     fn drive(&mut self) -> Result<(), DiscoveryError> {
         while self.catalog.is_none() {
-            let Some(index) = self.candidates.iter().position(|candidate| matches!(candidate.state, CandidateState::New) || matches!(candidate.state, CandidateState::Waiting(id) if self.outcomes.contains_key(&id))) else {
-                if self.requests.values().any(|need| !self.outcomes.contains_key(&need.id)) { return Ok(()); }
-                if self.candidates.iter().all(|candidate| matches!(candidate.state, CandidateState::Rejected)) {
-                    return Err(DiscoveryError::NoCandidateAccepted { diagnostics: self.diagnostics.clone() });
+            let Some(index) = self
+                .candidates
+                .iter()
+                .position(|candidate| self.ready(candidate.state))
+            else {
+                let pending = self.requests.iter().any(|r| r.outcome.is_none())
+                    || self
+                        .candidates
+                        .iter()
+                        .any(|c| !matches!(c.state, CandidateState::Rejected));
+                if pending {
+                    return Ok(());
                 }
-                return Ok(());
+                return Err(DiscoveryError::NoCandidateAccepted {
+                    diagnostics: self.diagnostics.clone(),
+                });
             };
             self.transitions += 1;
             if self.transitions > self.limits.transitions {
@@ -673,11 +481,8 @@ impl DiscoveryOperation {
                 .advance_candidate(index)
                 .and_then(|step| self.apply_step(index, step));
             match result {
-                Ok(()) => {}
-                Err(DiscoveryError::Session(message)) => {
-                    self.reject_candidate(index, message);
-                }
-                Err(error) => return Err(error),
+                Err(DiscoveryError::Session(message)) => self.reject_candidate(index, message),
+                result => result?,
             }
         }
         Ok(())
@@ -685,54 +490,48 @@ impl DiscoveryOperation {
 
     fn advance_candidate(&mut self, index: usize) -> Result<DiscoveryStep, DiscoveryError> {
         let candidate = &self.candidates[index];
-        let state = match candidate.state {
-            CandidateState::New => None,
-            CandidateState::Waiting(id) => Some(id),
-            CandidateState::Rejected => unreachable!("rejected candidates are not driven"),
-        };
-
-        if state.is_none() && !(candidate.spec.recognize)(&self.input.uri) {
-            return Err(DiscoveryError::Session(candidate.spec.rejection.into()));
+        if matches!(candidate.state, CandidateState::New) {
+            if !(candidate.spec.recognize)(&self.input) {
+                return Err(DiscoveryError::Session(candidate.spec.rejection.into()));
+            }
+            return match candidate.spec.program {
+                DiscoveryProgram::Immediate(complete) => {
+                    complete(&self.input).map(DiscoveryStep::Complete)
+                }
+                DiscoveryProgram::Rules(..) => {
+                    Ok(DiscoveryStep::Follow(Request::new(self.input.clone())))
+                }
+            };
         }
 
-        match (candidate.spec.program, state) {
-            (DiscoveryProgram::Immediate(complete), None) => {
-                complete(&self.input.uri).map(DiscoveryStep::Complete)
-            }
-            (DiscoveryProgram::Immediate(_), Some(_)) => {
-                unreachable!("immediate dezoomers never follow resources")
-            }
-            (DiscoveryProgram::Rules { .. }, None) => {
-                Ok(DiscoveryStep::Follow(Request::new(self.input.uri.clone())))
-            }
-            (DiscoveryProgram::Rules { routes, on_failure }, Some(id)) => {
-                let request = &self.requests[&id].request;
-                let previous_history = candidate
-                    .history
-                    .strip_suffix(&[id])
-                    .expect("the current resource is last in candidate history");
-                let context = DiscoveryContext {
-                    history_ids: previous_history,
-                    requests: &self.requests,
-                    outcomes: &self.outcomes,
-                };
-                match self
-                    .outcomes
-                    .get(&id)
-                    .expect("ready candidate has an outcome")
-                {
-                    ResourceOutcome::Response(response) => dispatch_resource(
-                        routes,
-                        &context,
-                        DiscoveryResource { request, response },
-                        "resource did not match any discovery route",
-                    ),
-                    ResourceOutcome::Failure(failure) => on_failure.map_or_else(
-                        || Err(DiscoveryError::Session(failure.message.clone())),
-                        |handler| handler(&context, DiscoveryFailure { request, failure }),
-                    ),
-                }
-            }
+        let CandidateState::Waiting(id) = candidate.state else {
+            unreachable!("rejected candidates are not driven");
+        };
+        let DiscoveryProgram::Rules(routes, on_failure) = candidate.spec.program else {
+            unreachable!("immediate dezoomers never follow resources");
+        };
+        let resource = self.resource(id).expect("ready request exists");
+        let request = &resource.request;
+        let previous_history = &candidate.history[..candidate.history.len() - 1];
+        let context = DiscoveryContext {
+            history_ids: previous_history,
+            requests: &self.requests,
+        };
+        match resource
+            .outcome
+            .as_ref()
+            .expect("ready candidate has an outcome")
+        {
+            ResourceOutcome::Response(bytes) => dispatch_resource(
+                routes,
+                &context,
+                DiscoveryResource { request, bytes },
+                "resource did not match any discovery route",
+            ),
+            ResourceOutcome::Failure(failure) => on_failure.map_or_else(
+                || Err(DiscoveryError::Session(failure.message.clone())),
+                |handler| handler(&context, request, failure),
+            ),
         }
     }
 
@@ -740,32 +539,29 @@ impl DiscoveryOperation {
         match step {
             DiscoveryStep::Follow(request) => {
                 let request = match self.candidates[index].spec.program {
-                    DiscoveryProgram::Rules { routes, .. } => map_url(routes, &request.uri)?,
+                    DiscoveryProgram::Rules(routes, ..) => map_url(routes, request)?,
                     DiscoveryProgram::Immediate(_) => request,
                 };
-                match self.register_request(request) {
-                    Ok(id) => {
-                        if self.candidates[index].history.contains(&id) {
-                            self.reject_candidate(
-                                index,
-                                "discovery followed the same resource twice".into(),
-                            );
-                        } else {
-                            self.candidates[index].history.push(id);
-                            self.candidates[index].state = CandidateState::Waiting(id);
-                        }
-                    }
-                    Err(DiscoveryError::ResourceLimitExceeded) => {
-                        self.reject_candidate(index, "discovery resource limit exceeded".into());
-                    }
-                    Err(error) => return Err(error),
+                let Some(id) = self.register_request(request) else {
+                    self.reject_candidate(index, "discovery resource limit exceeded".into());
+                    return Ok(());
+                };
+                if self.candidates[index].history.contains(&id) {
+                    self.reject_candidate(
+                        index,
+                        "discovery followed the same resource twice".into(),
+                    );
+                } else {
+                    self.candidates[index].history.push(id);
+                    self.candidates[index].state = CandidateState::Waiting(id);
                 }
             }
             DiscoveryStep::Complete(catalog) => {
-                let catalog = catalog
-                    .normalize()
-                    .map_err(|error| DiscoveryError::Session(error.to_string()))?;
-                self.catalog = Some(catalog);
+                self.catalog = Some(
+                    catalog
+                        .normalize()
+                        .map_err(|error| DiscoveryError::Session(error.to_string()))?,
+                );
             }
         }
         Ok(())
@@ -777,22 +573,28 @@ impl DiscoveryOperation {
         self.candidates[index].state = CandidateState::Rejected;
     }
 
-    fn register_request(&mut self, request: Request) -> Result<RequestId, DiscoveryError> {
-        if let Some(id) = self.request_ids.get(&request).copied() {
-            return Ok(id);
+    fn register_request(&mut self, request: Request) -> Option<RequestId> {
+        if let Some(index) = self
+            .requests
+            .iter()
+            .position(|resource| resource.request == request)
+        {
+            return Some(RequestId(index));
         }
         if self.requests.len() >= self.limits.resources {
-            return Err(DiscoveryError::ResourceLimitExceeded);
+            return None;
         }
-        let id = RequestId(self.next_request_id);
-        self.next_request_id += 1;
-        self.request_ids.insert(request.clone(), id);
-        self.requests.insert(id, ResourceNeed { id, request });
-        Ok(id)
+        let id = RequestId(self.requests.len());
+        self.requests.push(ResourceRecord {
+            request,
+            outcome: None,
+        });
+        Some(id)
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::unnecessary_wraps)]
 mod tests {
     use super::*;
     use crate::core::registry::Registry;
@@ -808,8 +610,8 @@ mod tests {
         Err(DiscoveryError::Session("wrong format".into()))
     }
 
-    const COMPLETE: &[DiscoveryRoute] = &[DiscoveryMatch::any().extract(catalog)];
-    const REJECT: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(reject)];
+    const COMPLETE: &[DiscoveryRoute] = &[DiscoveryMatch::Any.extract(catalog)];
+    const REJECT: &[DiscoveryRoute] = &[DiscoveryMatch::Any.then(reject)];
 
     fn provide(operation: &mut DiscoveryOperation, bytes: &[u8]) {
         let need = operation.missing_resources().unwrap().pop().unwrap();
@@ -840,8 +642,8 @@ mod tests {
     }
 
     const MAPPED: &[DiscoveryRoute] = &[
-        DiscoveryMatch::url_matching(is_tile).map_url(tile_metadata),
-        DiscoveryMatch::url_suffix("/metadata").extract(catalog),
+        DiscoveryMatch::UrlPredicate(is_tile).map_url(tile_metadata),
+        DiscoveryMatch::UrlSuffix("/metadata").extract(catalog),
     ];
 
     #[test]
@@ -860,7 +662,9 @@ mod tests {
         resource: DiscoveryResource<'_>,
     ) -> Result<DiscoveryStep, DiscoveryError> {
         assert!(context.resources().next().is_none());
-        Ok(DiscoveryStep::follow(format!("{}/tiles", resource.uri())))
+        Ok(DiscoveryStep::Follow(
+            Request::new(format!("{}/tiles", resource.uri())).with_header("X-Test", "preserved"),
+        ))
     }
 
     fn finish_chain(
@@ -873,8 +677,8 @@ mod tests {
     }
 
     const CHAIN: &[DiscoveryRoute] = &[
-        DiscoveryMatch::url_suffix("/metadata").then(follow_tiles),
-        DiscoveryMatch::url_suffix("/tiles").then(finish_chain),
+        DiscoveryMatch::UrlSuffix("/metadata").then(follow_tiles),
+        DiscoveryMatch::UrlSuffix("/tiles").then(finish_chain),
     ];
 
     #[test]
@@ -883,9 +687,11 @@ mod tests {
         registry.register(DezoomerSpec::new("chain", CHAIN));
         let mut operation = registry.start("memory://image/metadata");
         provide(&mut operation, b"metadata");
+        let need = operation.next_priority_need().unwrap().unwrap();
+        assert_eq!(need.request.uri, "memory://image/metadata/tiles");
         assert_eq!(
-            operation.next_priority_need().unwrap().unwrap().request.uri,
-            "memory://image/metadata/tiles"
+            need.request.headers.get("X-Test").map(String::as_str),
+            Some("preserved")
         );
         provide(&mut operation, b"tiles");
         assert!(operation.finish().unwrap().is_empty());
@@ -900,6 +706,7 @@ mod tests {
         assert_eq!(operation.missing_resources().unwrap().len(), 1);
         provide(&mut operation, b"metadata");
         assert!(operation.is_complete());
+        assert!(operation.finish().unwrap().is_empty());
     }
 
     fn follow_a(
@@ -907,7 +714,7 @@ mod tests {
         _: DiscoveryResource<'_>,
     ) -> Result<DiscoveryStep, DiscoveryError> {
         assert!(context.resources().next().is_none());
-        Ok(DiscoveryStep::follow("memory://a"))
+        Ok(DiscoveryStep::Follow(Request::new("memory://a")))
     }
 
     fn follow_b(
@@ -915,11 +722,11 @@ mod tests {
         _: DiscoveryResource<'_>,
     ) -> Result<DiscoveryStep, DiscoveryError> {
         assert!(context.resources().next().is_none());
-        Ok(DiscoveryStep::follow("memory://b"))
+        Ok(DiscoveryStep::Follow(Request::new("memory://b")))
     }
 
-    const HISTORY_A: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(follow_a)];
-    const HISTORY_B: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(follow_b)];
+    const HISTORY_A: &[DiscoveryRoute] = &[DiscoveryMatch::Any.then(follow_a)];
+    const HISTORY_B: &[DiscoveryRoute] = &[DiscoveryMatch::Any.then(follow_b)];
 
     #[test]
     fn history_is_candidate_local_when_requests_are_shared() {
@@ -941,10 +748,11 @@ mod tests {
 
     fn recover(
         _: &DiscoveryContext<'_>,
-        failure: DiscoveryFailure<'_>,
+        request: &Request,
+        failure: &ResourceFailure,
     ) -> Result<DiscoveryStep, DiscoveryError> {
-        assert_eq!(failure.uri(), "memory://failure");
-        assert_eq!(failure.failure().message, "expected");
+        assert_eq!(request.uri, "memory://failure");
+        assert_eq!(failure.message, "expected");
         Ok(DiscoveryStep::Complete(ImageCatalog::default()))
     }
 
@@ -967,10 +775,10 @@ mod tests {
         _: &DiscoveryContext<'_>,
         resource: DiscoveryResource<'_>,
     ) -> Result<DiscoveryStep, DiscoveryError> {
-        Ok(DiscoveryStep::follow(resource.uri()))
+        Ok(DiscoveryStep::Follow(Request::new(resource.uri())))
     }
 
-    const REPEAT: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(repeat)];
+    const REPEAT: &[DiscoveryRoute] = &[DiscoveryMatch::Any.then(repeat)];
 
     #[test]
     fn following_the_same_uri_is_rejected() {
@@ -988,13 +796,13 @@ mod tests {
         context: &DiscoveryContext<'_>,
         _: DiscoveryResource<'_>,
     ) -> Result<DiscoveryStep, DiscoveryError> {
-        Ok(DiscoveryStep::follow(format!(
+        Ok(DiscoveryStep::Follow(Request::new(format!(
             "memory://{}",
             context.resources().count()
-        )))
+        ))))
     }
 
-    const LOOP: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(follow_again)];
+    const LOOP: &[DiscoveryRoute] = &[DiscoveryMatch::Any.then(follow_again)];
 
     #[test]
     fn operation_limits_are_enforced() {
@@ -1017,19 +825,37 @@ mod tests {
             .unwrap_err();
         assert_eq!(error, DiscoveryError::TransitionLimitExceeded);
 
-        let mut resources = registry.start_with_limits(
-            "memory://start",
+        let mut limited = Registry::new();
+        limited.register(DezoomerSpec::new("high", HIGH));
+        limited.register(DezoomerSpec::new("low", LOW));
+        let mut resources = limited.start_with_limits(
+            "memory://root",
             DiscoveryLimits {
-                resources: 1,
+                resources: 2,
                 ..Default::default()
             },
         );
-        let need = resources.missing_resources().unwrap().pop().unwrap();
-        assert!(
-            resources
-                .provide(ResourceResponse::new(need.id, []))
-                .is_err()
+        let high = resources
+            .missing_resources()
+            .unwrap()
+            .into_iter()
+            .find(|need| need.request.uri == "memory://high-1")
+            .unwrap();
+        assert_eq!(
+            resources.provide(ResourceResponse::new(high.id, [])),
+            Ok(())
         );
+        let low = resources
+            .missing_resources()
+            .unwrap()
+            .into_iter()
+            .find(|need| need.request.uri == "memory://low")
+            .unwrap();
+        resources
+            .provide(ResourceResponse::new(low.id, []))
+            .unwrap();
+        assert!(resources.is_complete());
+        assert!(resources.finish().unwrap().is_empty());
 
         let mut bytes = Registry::new();
         bytes.register(DezoomerSpec::new("bytes", COMPLETE));
@@ -1063,17 +889,17 @@ mod tests {
         _: &DiscoveryContext<'_>,
         _: DiscoveryResource<'_>,
     ) -> Result<DiscoveryStep, DiscoveryError> {
-        Ok(DiscoveryStep::follow("memory://high-2"))
+        Ok(DiscoveryStep::Follow(Request::new("memory://high-2")))
     }
 
     const HIGH: &[DiscoveryRoute] = &[
-        DiscoveryMatch::url_matching(is_root).map_url(high_start),
-        DiscoveryMatch::url_suffix("high-1").then(high_next),
-        DiscoveryMatch::url_suffix("high-2").extract(catalog),
+        DiscoveryMatch::UrlPredicate(is_root).map_url(high_start),
+        DiscoveryMatch::UrlSuffix("high-1").then(high_next),
+        DiscoveryMatch::UrlSuffix("high-2").extract(catalog),
     ];
     const LOW: &[DiscoveryRoute] = &[
-        DiscoveryMatch::url_matching(is_root).map_url(low_start),
-        DiscoveryMatch::any().extract(catalog),
+        DiscoveryMatch::UrlPredicate(is_root).map_url(low_start),
+        DiscoveryMatch::Any.extract(catalog),
     ];
 
     #[test]
@@ -1092,19 +918,6 @@ mod tests {
             operation.next_priority_need().unwrap().unwrap().request.uri,
             "memory://high-2"
         );
-    }
-
-    #[test]
-    fn media_type_matching_ignores_case_and_parameters() {
-        let request = Request::new("memory://page");
-        let response = ResourceResponse::new(RequestId(0), b"page")
-            .with_content_type("Text/HTML; charset=utf-8");
-        let resource = DiscoveryResource {
-            request: &request,
-            response: &response,
-        };
-        assert!(DiscoveryMatch::media_type(&["text/html"]).matches_resource(resource));
-        assert!(!DiscoveryMatch::media_type(&["text/xml"]).matches_resource(resource));
     }
 
     #[test]

--- a/dezoomify-core/src/core/discovery.rs
+++ b/dezoomify-core/src/core/discovery.rs
@@ -1,7 +1,8 @@
 //! Pure, resumable discovery orchestration.
 //!
-//! A discovery program only describes resource work.  The application owns
-//! fetching and repeatedly feeds outcomes back to [`DiscoveryOperation`].
+//! A discovery program declares how acquired resources are matched and what
+//! resource to follow next. The application owns acquisition and feeds each
+//! outcome to [`DiscoveryOperation`].
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -38,26 +39,30 @@ pub struct ResourceNeed {
     pub request: Request,
 }
 
-/// A resource request before the operation assigns its stable ID.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResourceRequest {
-    pub request: Request,
-}
-
-impl ResourceRequest {
-    #[must_use]
-    pub fn new(uri: impl Into<String>) -> Self {
-        Self {
-            request: Request::new(uri),
-        }
-    }
-}
-
 /// Bytes supplied by the application for a request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResourceResponse {
     pub id: RequestId,
     pub bytes: Vec<u8>,
+    /// HTTP media type, when the resource provider supplied one.
+    pub content_type: Option<String>,
+}
+
+impl ResourceResponse {
+    #[must_use]
+    pub fn new(id: RequestId, bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            id,
+            bytes: bytes.into(),
+            content_type: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_content_type(mut self, content_type: impl Into<String>) -> Self {
+        self.content_type = Some(content_type.into());
+        self
+    }
 }
 
 /// An application-reported failure to satisfy a request.
@@ -69,7 +74,7 @@ pub struct ResourceFailure {
 
 /// The resource result visible to a waiting program.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ResourceOutcome {
+enum ResourceOutcome {
     Response(ResourceResponse),
     Failure(ResourceFailure),
 }
@@ -92,62 +97,270 @@ impl Default for DiscoveryLimits {
     }
 }
 
-/// A deterministic reason a program did not recognize its input.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DiscoveryDiagnostic {
-    pub message: String,
+/// One declarative result yielded by a discovery rule.
+pub enum DiscoveryStep {
+    /// Continue discovery with another resource described by this request.
+    Follow(Request),
+    Complete(ImageCatalog),
 }
 
-impl From<&str> for DiscoveryDiagnostic {
-    fn from(message: &str) -> Self {
-        Self {
-            message: message.into(),
+impl DiscoveryStep {
+    #[must_use]
+    pub fn follow(uri: impl Into<String>) -> Self {
+        Self::Follow(Request::new(uri))
+    }
+}
+
+/// One successfully acquired resource.
+#[derive(Clone, Copy, Debug)]
+pub struct DiscoveryResource<'a> {
+    request: &'a Request,
+    response: &'a ResourceResponse,
+}
+
+impl<'a> DiscoveryResource<'a> {
+    #[must_use]
+    pub const fn uri(self) -> &'a str {
+        self.request.uri.as_str()
+    }
+
+    #[must_use]
+    pub fn bytes(self) -> &'a [u8] {
+        self.response.bytes.as_slice()
+    }
+
+    #[must_use]
+    pub fn content_type(self) -> Option<&'a str> {
+        self.response.content_type.as_deref()
+    }
+}
+
+/// One resource acquisition failure delivered to a failure rule.
+#[derive(Clone, Copy, Debug)]
+pub struct DiscoveryFailure<'a> {
+    request: &'a Request,
+    failure: &'a ResourceFailure,
+}
+
+impl<'a> DiscoveryFailure<'a> {
+    #[must_use]
+    pub const fn uri(self) -> &'a str {
+        self.request.uri.as_str()
+    }
+
+    #[must_use]
+    pub const fn failure(self) -> &'a ResourceFailure {
+        self.failure
+    }
+}
+
+/// Read-only state supplied to a declarative route handler.
+///
+/// History is local to this candidate even when requests are deduplicated
+/// across candidates.
+pub struct DiscoveryContext<'a> {
+    history_ids: &'a [RequestId],
+    requests: &'a BTreeMap<RequestId, ResourceNeed>,
+    outcomes: &'a BTreeMap<RequestId, ResourceOutcome>,
+}
+
+impl<'a> DiscoveryContext<'a> {
+    /// Earlier successful resources for this candidate, in discovery order.
+    #[must_use]
+    pub fn resources(&self) -> impl DoubleEndedIterator<Item = DiscoveryResource<'a>> + '_ {
+        self.history_ids.iter().filter_map(|id| {
+            let request = &self.requests.get(id)?.request;
+            let ResourceOutcome::Response(response) = self.outcomes.get(id)? else {
+                return None;
+            };
+            Some(DiscoveryResource { request, response })
+        })
+    }
+
+    /// Whether this candidate already followed a resource with this URI,
+    /// regardless of whether acquisition succeeded.
+    #[must_use]
+    pub fn has_visited(&self, uri: &str) -> bool {
+        self.history_ids.iter().any(|id| {
+            self.requests
+                .get(id)
+                .is_some_and(|resource| resource.request.uri == uri)
+        })
+    }
+}
+
+type RouteHandler = for<'a> fn(
+    &DiscoveryContext<'a>,
+    DiscoveryResource<'a>,
+) -> Result<DiscoveryStep, DiscoveryError>;
+type CatalogExtractor = fn(&str, &[u8]) -> Result<ImageCatalog, DiscoveryError>;
+type FailureHandler = for<'a> fn(
+    &DiscoveryContext<'a>,
+    DiscoveryFailure<'a>,
+) -> Result<DiscoveryStep, DiscoveryError>;
+type UrlMapper = fn(&str) -> Result<Request, DiscoveryError>;
+type UrlPredicate = fn(&str) -> bool;
+type ContentPredicate = fn(&[u8]) -> bool;
+
+/// A predicate for one declarative discovery route.
+#[derive(Clone, Copy, Debug)]
+pub enum DiscoveryMatch {
+    Any,
+    UrlSuffix(&'static str),
+    UrlPredicate(UrlPredicate),
+    MediaTypes(&'static [&'static str]),
+    ContentPredicate(ContentPredicate),
+}
+
+impl DiscoveryMatch {
+    #[must_use]
+    pub const fn any() -> Self {
+        Self::Any
+    }
+
+    #[must_use]
+    pub const fn url_suffix(suffix: &'static str) -> Self {
+        Self::UrlSuffix(suffix)
+    }
+
+    #[must_use]
+    pub const fn url_matching(predicate: UrlPredicate) -> Self {
+        Self::UrlPredicate(predicate)
+    }
+
+    #[must_use]
+    pub const fn media_type(media_types: &'static [&'static str]) -> Self {
+        Self::MediaTypes(media_types)
+    }
+
+    #[must_use]
+    pub const fn content_matching(predicate: ContentPredicate) -> Self {
+        Self::ContentPredicate(predicate)
+    }
+
+    /// Run a multi-resource handler for a matching acquired resource.
+    #[must_use]
+    pub const fn then(self, handler: RouteHandler) -> DiscoveryRoute {
+        DiscoveryRoute {
+            matcher: self,
+            handler: RouteAction::Then(handler),
+        }
+    }
+
+    /// Parse a matching resource directly into a catalog.
+    #[must_use]
+    pub const fn extract(self, extractor: CatalogExtractor) -> DiscoveryRoute {
+        DiscoveryRoute {
+            matcher: self,
+            handler: RouteAction::Extract(extractor),
+        }
+    }
+
+    /// Rewrite a matching input URI before the core acquires it.
+    #[must_use]
+    pub const fn map_url(self, mapper: UrlMapper) -> DiscoveryRoute {
+        DiscoveryRoute {
+            matcher: self,
+            handler: RouteAction::MapUrl(mapper),
+        }
+    }
+
+    fn matches_uri(self, uri: &str) -> bool {
+        let path = uri.split(['?', '#']).next().unwrap_or(uri);
+        match self {
+            Self::Any => true,
+            Self::UrlSuffix(suffix) => path.ends_with(suffix),
+            Self::UrlPredicate(predicate) => predicate(uri),
+            Self::MediaTypes(_) | Self::ContentPredicate(_) => false,
+        }
+    }
+
+    fn matches_resource(self, resource: DiscoveryResource<'_>) -> bool {
+        match self {
+            Self::Any => true,
+            Self::UrlSuffix(_) | Self::UrlPredicate(_) => self.matches_uri(resource.uri()),
+            Self::MediaTypes(types) => resource.content_type().is_some_and(|value| {
+                let media_type = value.split(';').next().unwrap_or(value).trim();
+                types
+                    .iter()
+                    .any(|expected| media_type.eq_ignore_ascii_case(expected))
+            }),
+            Self::ContentPredicate(predicate) => predicate(resource.bytes()),
         }
     }
 }
 
-impl From<String> for DiscoveryDiagnostic {
-    fn from(message: String) -> Self {
-        Self { message }
-    }
-}
-
-/// Input delivered to a program session.
-pub enum DiscoveryEvent<'a> {
-    /// The session's first transition.
-    Start,
-    /// A result for its preceding [`DiscoveryStep::Need`].
-    Resource(&'a ResourceOutcome),
-}
-
-/// One pure transition yielded by a discovery session.
-pub enum DiscoveryStep {
-    Need(ResourceRequest),
-    Complete(ImageCatalog),
-    Reject(DiscoveryDiagnostic),
-}
-
-/// One dezoomer: a pure parser state machine driven by [`DiscoveryOperation`].
-///
-/// Complex formats remain free to implement an object-safe, multi-resource
-/// state machine. Most formats use a routed [`DezoomerSpec`] instead.
-pub trait Dezoomer: Send {
-    /// Advance the parser from an input or one requested resource result.
-    ///
-    /// # Errors
-    ///
-    /// Returns a pure diagnostic when bytes or state cannot be interpreted.
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError>;
+/// An ordered declarative resource matcher and transition handler.
+#[derive(Clone, Copy, Debug)]
+pub struct DiscoveryRoute {
+    matcher: DiscoveryMatch,
+    handler: RouteAction,
 }
 
 #[derive(Clone, Copy, Debug)]
-enum SpecAdapter {
+enum RouteAction {
+    Then(RouteHandler),
+    Extract(CatalogExtractor),
+    MapUrl(UrlMapper),
+}
+
+impl DiscoveryRoute {
+    fn handle(
+        self,
+        context: &DiscoveryContext<'_>,
+        resource: DiscoveryResource<'_>,
+    ) -> Option<Result<DiscoveryStep, DiscoveryError>> {
+        if !self.matcher.matches_resource(resource) {
+            return None;
+        }
+        Some(match self.handler {
+            RouteAction::Then(handler) => handler(context, resource),
+            RouteAction::Extract(extractor) => {
+                extractor(resource.uri(), resource.bytes()).map(DiscoveryStep::Complete)
+            }
+            RouteAction::MapUrl(_) => return None,
+        })
+    }
+
+    fn map_url(self, uri: &str) -> Option<Result<Request, DiscoveryError>> {
+        let RouteAction::MapUrl(mapper) = self.handler else {
+            return None;
+        };
+        self.matcher.matches_uri(uri).then(|| mapper(uri))
+    }
+}
+
+fn dispatch_resource(
+    routes: &[DiscoveryRoute],
+    context: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+    unmatched: &str,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    for route in routes {
+        let Some(step) = route.handle(context, resource) else {
+            continue;
+        };
+        return step;
+    }
+    Err(DiscoveryError::Session(unmatched.into()))
+}
+
+fn map_url(routes: &[DiscoveryRoute], uri: &str) -> Result<Request, DiscoveryError> {
+    for route in routes {
+        if let Some(mapped) = route.map_url(uri) {
+            return mapped;
+        }
+    }
+    Ok(Request::new(uri))
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DiscoveryProgram {
     Immediate(fn(&str) -> Result<ImageCatalog, DiscoveryError>),
-    Resource {
-        request: fn(&str) -> Result<ResourceRequest, DiscoveryError>,
-        parse: fn(&str, &[u8]) -> Result<ImageCatalog, DiscoveryError>,
+    Rules {
+        routes: &'static [DiscoveryRoute],
+        on_failure: Option<FailureHandler>,
     },
-    Stateful(fn(&DiscoveryInput) -> Box<dyn Dezoomer>),
 }
 
 /// One co-located format declaration.
@@ -157,45 +370,54 @@ pub struct DezoomerSpec {
     recognize: fn(&str) -> bool,
     rejection: &'static str,
     prefer: fn(&str) -> bool,
-    adapter: SpecAdapter,
+    program: DiscoveryProgram,
 }
 
 impl DezoomerSpec {
+    /// Declare ordered rules for resources acquired by the core.
+    ///
+    /// The core acquires the input URI automatically and dispatches every
+    /// successful resource through the same ordered rule list.
+    #[must_use]
+    pub const fn new(name: &'static str, routes: &'static [DiscoveryRoute]) -> Self {
+        Self::from_program(
+            name,
+            DiscoveryProgram::Rules {
+                routes,
+                on_failure: None,
+            },
+        )
+    }
+
     /// Declare a format which completes from its input without a resource.
     #[must_use]
     pub const fn immediate(
         name: &'static str,
         complete: fn(&str) -> Result<ImageCatalog, DiscoveryError>,
     ) -> Self {
-        Self::new(name, SpecAdapter::Immediate(complete))
+        Self::from_program(name, DiscoveryProgram::Immediate(complete))
     }
 
-    /// Declare a format which parses one derived resource.
+    /// Handle acquisition failures for formats with alternate resources.
     #[must_use]
-    pub const fn routed(
-        name: &'static str,
-        request: fn(&str) -> Result<ResourceRequest, DiscoveryError>,
-        parse: fn(&str, &[u8]) -> Result<ImageCatalog, DiscoveryError>,
-    ) -> Self {
-        Self::new(name, SpecAdapter::Resource { request, parse })
+    pub const fn on_failure(mut self, handler: FailureHandler) -> Self {
+        let DiscoveryProgram::Rules { routes, .. } = self.program else {
+            panic!("an immediate dezoomer cannot handle resource failures");
+        };
+        self.program = DiscoveryProgram::Rules {
+            routes,
+            on_failure: Some(handler),
+        };
+        self
     }
 
-    /// Declare a format backed by an object-safe, multi-resource state machine.
-    #[must_use]
-    pub const fn stateful(
-        name: &'static str,
-        start: fn(&DiscoveryInput) -> Box<dyn Dezoomer>,
-    ) -> Self {
-        Self::new(name, SpecAdapter::Stateful(start))
-    }
-
-    const fn new(name: &'static str, adapter: SpecAdapter) -> Self {
+    const fn from_program(name: &'static str, program: DiscoveryProgram) -> Self {
         Self {
             name,
             recognize: |_| true,
             rejection: "input not recognized",
             prefer: |_| false,
-            adapter,
+            program,
         }
     }
 
@@ -233,11 +455,6 @@ impl DezoomerSpec {
     }
 }
 
-/// Request the input URI unchanged.
-pub fn input_resource(uri: &str) -> Result<ResourceRequest, DiscoveryError> {
-    Ok(ResourceRequest::new(uri))
-}
-
 impl PartialEq for DezoomerSpec {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
@@ -249,9 +466,7 @@ impl PartialEq for DezoomerSpec {
 pub enum DiscoveryError {
     UnknownRequest(RequestId),
     RequestAlreadyProvided(RequestId),
-    NoCandidateAccepted {
-        diagnostics: Vec<(String, DiscoveryDiagnostic)>,
-    },
+    NoCandidateAccepted { diagnostics: Vec<(String, String)> },
     NotComplete,
     Session(String),
     TransitionLimitExceeded,
@@ -267,7 +482,7 @@ impl fmt::Display for DiscoveryError {
             Self::NoCandidateAccepted { diagnostics } => {
                 f.write_str("no discovery candidate accepted the input")?;
                 for (id, diagnostic) in diagnostics {
-                    write!(f, "\n - {id}: {}", diagnostic.message)?;
+                    write!(f, "\n - {id}: {diagnostic}")?;
                 }
                 Ok(())
             }
@@ -293,8 +508,8 @@ enum CandidateState {
 
 struct Candidate {
     spec: DezoomerSpec,
-    session: Option<Box<dyn Dezoomer>>,
     state: CandidateState,
+    history: Vec<RequestId>,
 }
 
 /// A pull-driven operation with no I/O or shared mutable parser state.
@@ -304,7 +519,7 @@ pub struct DiscoveryOperation {
     requests: BTreeMap<RequestId, ResourceNeed>,
     request_ids: BTreeMap<Request, RequestId>,
     outcomes: BTreeMap<RequestId, ResourceOutcome>,
-    diagnostics: Vec<(String, DiscoveryDiagnostic)>,
+    diagnostics: Vec<(String, String)>,
     catalog: Option<ImageCatalog>,
     next_request_id: u64,
     transitions: usize,
@@ -322,11 +537,8 @@ impl DiscoveryOperation {
         for spec in specs {
             candidates.push(Candidate {
                 spec: *spec,
-                session: match spec.adapter {
-                    SpecAdapter::Stateful(start) => Some(start(input)),
-                    SpecAdapter::Immediate(_) | SpecAdapter::Resource { .. } => None,
-                },
                 state: CandidateState::New,
+                history: Vec::new(),
             });
         }
         // Registry validation and URL ranking supply the canonical candidate
@@ -463,7 +675,7 @@ impl DiscoveryOperation {
             match result {
                 Ok(()) => {}
                 Err(DiscoveryError::Session(message)) => {
-                    self.reject_candidate(index, DiscoveryDiagnostic::from(message));
+                    self.reject_candidate(index, message);
                 }
                 Err(error) => return Err(error),
             }
@@ -480,44 +692,45 @@ impl DiscoveryOperation {
         };
 
         if state.is_none() && !(candidate.spec.recognize)(&self.input.uri) {
-            return Ok(DiscoveryStep::Reject(candidate.spec.rejection.into()));
+            return Err(DiscoveryError::Session(candidate.spec.rejection.into()));
         }
 
-        match candidate.spec.adapter {
-            SpecAdapter::Immediate(complete) => {
-                debug_assert!(state.is_none());
+        match (candidate.spec.program, state) {
+            (DiscoveryProgram::Immediate(complete), None) => {
                 complete(&self.input.uri).map(DiscoveryStep::Complete)
             }
-            SpecAdapter::Resource { request, parse } => match state {
-                None => request(&self.input.uri).map(DiscoveryStep::Need),
-                Some(id) => match self
+            (DiscoveryProgram::Immediate(_), Some(_)) => {
+                unreachable!("immediate dezoomers never follow resources")
+            }
+            (DiscoveryProgram::Rules { .. }, None) => {
+                Ok(DiscoveryStep::Follow(Request::new(self.input.uri.clone())))
+            }
+            (DiscoveryProgram::Rules { routes, on_failure }, Some(id)) => {
+                let request = &self.requests[&id].request;
+                let previous_history = candidate
+                    .history
+                    .strip_suffix(&[id])
+                    .expect("the current resource is last in candidate history");
+                let context = DiscoveryContext {
+                    history_ids: previous_history,
+                    requests: &self.requests,
+                    outcomes: &self.outcomes,
+                };
+                match self
                     .outcomes
                     .get(&id)
                     .expect("ready candidate has an outcome")
                 {
-                    ResourceOutcome::Response(response) => {
-                        let uri = &self.requests[&id].request.uri;
-                        parse(uri, &response.bytes).map(DiscoveryStep::Complete)
-                    }
-                    ResourceOutcome::Failure(failure) => {
-                        Err(DiscoveryError::Session(failure.message.clone()))
-                    }
-                },
-            },
-            SpecAdapter::Stateful(_) => {
-                let outcome = state.map(|id| {
-                    self.outcomes
-                        .get(&id)
-                        .expect("ready candidate has an outcome")
-                        .clone()
-                });
-                let session = self.candidates[index]
-                    .session
-                    .as_mut()
-                    .expect("stateful adapter has a session");
-                match outcome.as_ref() {
-                    None => session.advance(DiscoveryEvent::Start),
-                    Some(outcome) => session.advance(DiscoveryEvent::Resource(outcome)),
+                    ResourceOutcome::Response(response) => dispatch_resource(
+                        routes,
+                        &context,
+                        DiscoveryResource { request, response },
+                        "resource did not match any discovery route",
+                    ),
+                    ResourceOutcome::Failure(failure) => on_failure.map_or_else(
+                        || Err(DiscoveryError::Session(failure.message.clone())),
+                        |handler| handler(&context, DiscoveryFailure { request, failure }),
+                    ),
                 }
             }
         }
@@ -525,37 +738,47 @@ impl DiscoveryOperation {
 
     fn apply_step(&mut self, index: usize, step: DiscoveryStep) -> Result<(), DiscoveryError> {
         match step {
-            DiscoveryStep::Need(request) => match self.register_request(request) {
-                Ok(id) => self.candidates[index].state = CandidateState::Waiting(id),
-                Err(DiscoveryError::ResourceLimitExceeded) => {
-                    self.reject_candidate(
-                        index,
-                        DiscoveryDiagnostic::from("discovery resource limit exceeded"),
-                    );
+            DiscoveryStep::Follow(request) => {
+                let request = match self.candidates[index].spec.program {
+                    DiscoveryProgram::Rules { routes, .. } => map_url(routes, &request.uri)?,
+                    DiscoveryProgram::Immediate(_) => request,
+                };
+                match self.register_request(request) {
+                    Ok(id) => {
+                        if self.candidates[index].history.contains(&id) {
+                            self.reject_candidate(
+                                index,
+                                "discovery followed the same resource twice".into(),
+                            );
+                        } else {
+                            self.candidates[index].history.push(id);
+                            self.candidates[index].state = CandidateState::Waiting(id);
+                        }
+                    }
+                    Err(DiscoveryError::ResourceLimitExceeded) => {
+                        self.reject_candidate(index, "discovery resource limit exceeded".into());
+                    }
+                    Err(error) => return Err(error),
                 }
-                Err(error) => return Err(error),
-            },
+            }
             DiscoveryStep::Complete(catalog) => {
                 let catalog = catalog
                     .normalize()
                     .map_err(|error| DiscoveryError::Session(error.to_string()))?;
                 self.catalog = Some(catalog);
             }
-            DiscoveryStep::Reject(diagnostic) => {
-                self.reject_candidate(index, diagnostic);
-            }
         }
         Ok(())
     }
 
-    fn reject_candidate(&mut self, index: usize, diagnostic: DiscoveryDiagnostic) {
+    fn reject_candidate(&mut self, index: usize, diagnostic: String) {
         let id = self.candidates[index].spec.name.to_owned();
         self.diagnostics.push((id, diagnostic));
         self.candidates[index].state = CandidateState::Rejected;
     }
 
-    fn register_request(&mut self, request: ResourceRequest) -> Result<RequestId, DiscoveryError> {
-        if let Some(id) = self.request_ids.get(&request.request).copied() {
+    fn register_request(&mut self, request: Request) -> Result<RequestId, DiscoveryError> {
+        if let Some(id) = self.request_ids.get(&request).copied() {
             return Ok(id);
         }
         if self.requests.len() >= self.limits.resources {
@@ -563,14 +786,8 @@ impl DiscoveryOperation {
         }
         let id = RequestId(self.next_request_id);
         self.next_request_id += 1;
-        self.request_ids.insert(request.request.clone(), id);
-        self.requests.insert(
-            id,
-            ResourceNeed {
-                id,
-                request: request.request,
-            },
-        );
+        self.request_ids.insert(request.clone(), id);
+        self.requests.insert(id, ResourceNeed { id, request });
         Ok(id)
     }
 }
@@ -579,359 +796,328 @@ impl DiscoveryOperation {
 mod tests {
     use super::*;
     use crate::core::registry::Registry;
-    use crate::core::{CatalogEntry, DeferredImage, StableId};
 
-    const REJECTING_SHARED: DezoomerSpec = DezoomerSpec::routed(
-        "rejecting",
-        |_| Ok(ResourceRequest::new("memory://shared")),
-        |_, _| Err(DiscoveryError::Session("wrong metadata".into())),
-    );
-    const ACCEPTING_SHARED: DezoomerSpec = DezoomerSpec::routed(
-        "accepting",
-        |_| Ok(ResourceRequest::new("memory://shared")),
-        |_, _| Ok(ImageCatalog::default()),
-    );
-    const BROKEN: DezoomerSpec = DezoomerSpec::immediate("broken", |_| {
-        Err(DiscoveryError::Session("not my format".into()))
-    });
-    const WORKING: DezoomerSpec = DezoomerSpec::routed(
-        "working",
-        |_| Ok(ResourceRequest::new("memory://working")),
-        |_, _| Ok(ImageCatalog::default()),
-    );
-    const ONE_META: DezoomerSpec = DezoomerSpec::routed(
-        "one",
-        |_| Ok(ResourceRequest::new("memory://meta")),
-        |_, _| Ok(ImageCatalog::default()),
-    );
-    const LOW: DezoomerSpec = DezoomerSpec::routed(
-        "low",
-        |_| Ok(ResourceRequest::new("memory://low1")),
-        |_, _| Ok(ImageCatalog::default()),
-    );
-    const A: DezoomerSpec = DezoomerSpec::routed(
-        "a",
-        |_| Ok(ResourceRequest::new("memory://a")),
-        |_, _| Ok(ImageCatalog::default()),
-    );
-    const B: DezoomerSpec = DezoomerSpec::routed(
-        "b",
-        |_| Ok(ResourceRequest::new("memory://b")),
-        |_, _| Ok(ImageCatalog::default()),
-    );
-    const C: DezoomerSpec = DezoomerSpec::routed(
-        "c",
-        |_| Ok(ResourceRequest::new("memory://c")),
-        |_, _| Ok(ImageCatalog::default()),
-    );
-
-    struct Chain {
-        state: u8,
-        first: &'static str,
-        second: &'static str,
+    fn catalog(_: &str, _: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
+        Ok(ImageCatalog::default())
     }
 
-    impl Dezoomer for Chain {
-        fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-            match (self.state, event) {
-                (0, DiscoveryEvent::Start) => {
-                    self.state = 1;
-                    Ok(DiscoveryStep::Need(ResourceRequest::new(self.first)))
-                }
-                (1, DiscoveryEvent::Resource(ResourceOutcome::Response(_))) => {
-                    self.state = 2;
-                    Ok(DiscoveryStep::Need(ResourceRequest::new(self.second)))
-                }
-                (2, DiscoveryEvent::Resource(ResourceOutcome::Response(_))) => {
-                    Ok(DiscoveryStep::Complete(ImageCatalog::default()))
-                }
-                _ => Ok(DiscoveryStep::Reject("unexpected".into())),
-            }
-        }
+    fn reject(
+        _: &DiscoveryContext<'_>,
+        _: DiscoveryResource<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        Err(DiscoveryError::Session("wrong format".into()))
     }
 
-    fn chain(first: &'static str, second: &'static str) -> Box<dyn Dezoomer> {
-        Box::new(Chain {
-            state: 0,
-            first,
-            second,
-        })
-    }
+    const COMPLETE: &[DiscoveryRoute] = &[DiscoveryMatch::any().extract(catalog)];
+    const REJECT: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(reject)];
 
-    const STATEFUL_CHAIN: DezoomerSpec =
-        DezoomerSpec::stateful("chain", |_| chain("memory://metadata", "memory://tiles"));
-    const HIGH_CHAIN: DezoomerSpec =
-        DezoomerSpec::stateful("high", |_| chain("memory://high1", "memory://high2"));
-
-    struct Loop(usize);
-    impl Dezoomer for Loop {
-        fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-            match event {
-                DiscoveryEvent::Start => Ok(DiscoveryStep::Need(ResourceRequest::new(format!(
-                    "memory://loop{}",
-                    self.0
-                )))),
-                DiscoveryEvent::Resource(ResourceOutcome::Response(_)) => {
-                    self.0 += 1;
-                    Ok(DiscoveryStep::Need(ResourceRequest::new(format!(
-                        "memory://loop{}",
-                        self.0
-                    ))))
-                }
-                DiscoveryEvent::Resource(ResourceOutcome::Failure(_)) => {
-                    Ok(DiscoveryStep::Reject("done".into()))
-                }
-            }
-        }
-    }
-
-    impl Loop {
-        const SPEC: DezoomerSpec = DezoomerSpec::stateful("loop", Self::start);
-
-        fn start(_: &DiscoveryInput) -> Box<dyn Dezoomer> {
-            Box::new(Self(0))
-        }
-    }
-
-    fn need_response(operation: &mut DiscoveryOperation, bytes: &[u8]) {
-        let need = operation.missing_resources().unwrap();
-        assert_eq!(need.len(), 1);
-        provide_response(operation, need[0].id, bytes);
-    }
-
-    fn provide_response(operation: &mut DiscoveryOperation, id: RequestId, bytes: &[u8]) {
+    fn provide(operation: &mut DiscoveryOperation, bytes: &[u8]) {
+        let need = operation.missing_resources().unwrap().pop().unwrap();
         operation
-            .provide(ResourceResponse {
-                id,
-                bytes: bytes.to_vec(),
-            })
+            .provide(ResourceResponse::new(need.id, bytes))
             .unwrap();
     }
 
-    fn derived_request(input: &str) -> ResourceRequest {
-        ResourceRequest::new(format!("{input}/metadata"))
-    }
-
-    fn catalog_with_context(uri: &str) -> ImageCatalog {
-        ImageCatalog::new([CatalogEntry::Deferred(DeferredImage {
-            id: StableId::new("routed:0"),
-            uri: uri.to_owned(),
-            title: None,
-            warnings: Vec::new(),
-        })])
-    }
-
-    const ROUTED: DezoomerSpec = DezoomerSpec::routed(
-        "routed",
-        |uri| Ok(derived_request(uri)),
-        |uri, _| Ok(catalog_with_context(uri)),
-    )
-    .recognizing(|uri| uri.starts_with("route:"), "not a routed input")
-    .preferring(|uri| uri.ends_with("preferred"));
-
     #[test]
-    fn route_adapter_recognizes_derives_and_parses_with_resource_context() {
-        assert!(ROUTED.prefers("route:preferred"));
+    fn input_acquisition_is_implicit_and_extractors_receive_it() {
         let mut registry = Registry::new();
-        registry.register(ROUTED);
-        let mut operation = registry.start("route:input");
+        registry.register(DezoomerSpec::new("test", COMPLETE));
+        let mut operation = registry.start("memory://metadata");
         let need = operation.missing_resources().unwrap().pop().unwrap();
-        assert_eq!(need.request.uri, "route:input/metadata");
-        provide_response(&mut operation, need.id, b"metadata");
-        let catalog = operation.finish().unwrap();
-        let [CatalogEntry::Deferred(image)] = catalog.entries() else {
-            panic!("route parser should return its deferred image")
-        };
-        assert_eq!(image.uri, need.request.uri);
-
-        let mut rejected = registry.start("other:input");
-        assert!(matches!(
-            rejected.missing_resources(),
-            Err(DiscoveryError::NoCandidateAccepted { .. })
-        ));
+        assert_eq!(need.request.uri, "memory://metadata");
+        operation
+            .provide(ResourceResponse::new(need.id, b"metadata"))
+            .unwrap();
+        assert!(operation.finish().unwrap().is_empty());
     }
 
-    #[test]
-    fn candidate_diagnostics_are_displayed_one_per_line() {
-        let error = DiscoveryError::NoCandidateAccepted {
-            diagnostics: vec![
-                (
-                    "first".into(),
-                    DiscoveryDiagnostic::from("not a first input"),
-                ),
-                (
-                    "second".into(),
-                    DiscoveryDiagnostic::from("not a second input"),
-                ),
-            ],
-        };
+    fn is_tile(uri: &str) -> bool {
+        uri.ends_with("/tile.jpg")
+    }
 
+    fn tile_metadata(uri: &str) -> Result<Request, DiscoveryError> {
+        Ok(Request::new(uri.replace("/tile.jpg", "/metadata")))
+    }
+
+    const MAPPED: &[DiscoveryRoute] = &[
+        DiscoveryMatch::url_matching(is_tile).map_url(tile_metadata),
+        DiscoveryMatch::url_suffix("/metadata").extract(catalog),
+    ];
+
+    #[test]
+    fn url_mapping_happens_before_acquisition() {
+        let mut registry = Registry::new();
+        registry.register(DezoomerSpec::new("mapped", MAPPED));
+        let mut operation = registry.start("memory://image/tile.jpg");
         assert_eq!(
-            error.to_string(),
-            "no discovery candidate accepted the input\n - first: not a first input\n - second: not a second input"
+            operation.next_priority_need().unwrap().unwrap().request.uri,
+            "memory://image/metadata"
         );
     }
 
-    #[test]
-    fn identical_requests_are_fanned_out_to_candidates_once() {
-        let mut registry = Registry::new();
-        registry.register(REJECTING_SHARED);
-        registry.register(ACCEPTING_SHARED);
-
-        let mut operation = registry.start("memory://root");
-        assert_eq!(operation.missing_resources().unwrap().len(), 1);
-        need_response(&mut operation, b"metadata");
-        assert!(operation.is_complete());
+    fn follow_tiles(
+        context: &DiscoveryContext<'_>,
+        resource: DiscoveryResource<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        assert!(context.resources().next().is_none());
+        Ok(DiscoveryStep::follow(format!("{}/tiles", resource.uri())))
     }
 
-    #[test]
-    fn session_errors_reject_one_candidate_and_continue() {
-        let mut registry = Registry::new();
-        registry.register(BROKEN);
-        registry.register(WORKING);
+    fn finish_chain(
+        context: &DiscoveryContext<'_>,
+        resource: DiscoveryResource<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        assert!(resource.uri().ends_with("/tiles"));
+        assert_eq!(context.resources().count(), 1);
+        Ok(DiscoveryStep::Complete(ImageCatalog::default()))
+    }
 
-        let mut operation = registry.start("memory://root");
-        let needs = operation.missing_resources().unwrap();
-        assert_eq!(needs[0].request.uri, "memory://working");
-        provide_response(&mut operation, needs[0].id, b"");
+    const CHAIN: &[DiscoveryRoute] = &[
+        DiscoveryMatch::url_suffix("/metadata").then(follow_tiles),
+        DiscoveryMatch::url_suffix("/tiles").then(finish_chain),
+    ];
+
+    #[test]
+    fn followed_resources_are_redispatched_with_history() {
+        let mut registry = Registry::new();
+        registry.register(DezoomerSpec::new("chain", CHAIN));
+        let mut operation = registry.start("memory://image/metadata");
+        provide(&mut operation, b"metadata");
+        assert_eq!(
+            operation.next_priority_need().unwrap().unwrap().request.uri,
+            "memory://image/metadata/tiles"
+        );
+        provide(&mut operation, b"tiles");
         assert!(operation.finish().unwrap().is_empty());
     }
 
     #[test]
-    fn parser_state_is_local_to_each_operation() {
+    fn identical_requests_are_fanned_out_and_parser_errors_try_the_next_candidate() {
         let mut registry = Registry::new();
-        registry.register(STATEFUL_CHAIN);
-        let mut first = registry.start("memory://first");
-        let mut second = registry.start("memory://second");
-        let first_id = first.missing_resources().unwrap()[0].id;
-        let second_id = second.missing_resources().unwrap()[0].id;
-        assert_eq!(first_id, second_id);
-        provide_response(&mut first, first_id, b"");
-        assert_eq!(
-            first.next_priority_need().unwrap().unwrap().request.uri,
-            "memory://tiles"
-        );
-        assert!(!second.is_complete());
-        assert_eq!(
-            second.next_priority_need().unwrap().unwrap().request.uri,
-            "memory://metadata"
-        );
-    }
-
-    #[test]
-    fn priority_scheduling_fetches_higher_priority_chain_first() {
-        let mut registry = Registry::new();
-        registry.register(HIGH_CHAIN);
-        registry.register(LOW);
-
-        let mut operation = registry.start("memory://root");
-        let needs = operation.missing_resources().unwrap();
-        assert_eq!(needs.len(), 2);
-        assert!(needs.iter().any(|n| n.request.uri == "memory://high1"));
-        assert!(needs.iter().any(|n| n.request.uri == "memory://low1"));
-        let next = operation.next_priority_need().unwrap().unwrap();
-        assert_eq!(next.request.uri, "memory://high1");
-        provide_response(&mut operation, next.id, b"");
-        let needs = operation.missing_resources().unwrap();
-        assert_eq!(needs.len(), 2);
-        let prio = operation.next_priority_need().unwrap().unwrap();
-        assert_eq!(
-            prio.request.uri, "memory://high2",
-            "higher-priority second request must be fetched before lower-priority first"
-        );
-        provide_response(&mut operation, prio.id, b"");
+        registry.register(DezoomerSpec::new("reject", REJECT));
+        registry.register(DezoomerSpec::new("accept", COMPLETE));
+        let mut operation = registry.start("memory://shared");
+        assert_eq!(operation.missing_resources().unwrap().len(), 1);
+        provide(&mut operation, b"metadata");
         assert!(operation.is_complete());
     }
 
+    fn follow_a(
+        context: &DiscoveryContext<'_>,
+        _: DiscoveryResource<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        assert!(context.resources().next().is_none());
+        Ok(DiscoveryStep::follow("memory://a"))
+    }
+
+    fn follow_b(
+        context: &DiscoveryContext<'_>,
+        _: DiscoveryResource<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        assert!(context.resources().next().is_none());
+        Ok(DiscoveryStep::follow("memory://b"))
+    }
+
+    const HISTORY_A: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(follow_a)];
+    const HISTORY_B: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(follow_b)];
+
     #[test]
-    fn completed_operations_have_no_outstanding_resources() {
+    fn history_is_candidate_local_when_requests_are_shared() {
         let mut registry = Registry::new();
-        registry.register(WORKING);
-        let mut operation = registry.start("memory://root");
+        registry.register(DezoomerSpec::new("a", HISTORY_A));
+        registry.register(DezoomerSpec::new("b", HISTORY_B));
+        let mut operation = registry.start("memory://shared");
+        let shared = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(shared.id, b"shared"))
+            .unwrap();
+        assert_eq!(operation.candidates[0].history[0], shared.id);
+        assert_eq!(operation.candidates[1].history[0], shared.id);
+        assert_ne!(
+            operation.candidates[0].history[1],
+            operation.candidates[1].history[1]
+        );
+    }
+
+    fn recover(
+        _: &DiscoveryContext<'_>,
+        failure: DiscoveryFailure<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        assert_eq!(failure.uri(), "memory://failure");
+        assert_eq!(failure.failure().message, "expected");
+        Ok(DiscoveryStep::Complete(ImageCatalog::default()))
+    }
+
+    #[test]
+    fn failure_handlers_choose_the_next_action() {
+        let mut registry = Registry::new();
+        registry.register(DezoomerSpec::new("failure", COMPLETE).on_failure(recover));
+        let mut operation = registry.start("memory://failure");
         let need = operation.missing_resources().unwrap().pop().unwrap();
-        provide_response(&mut operation, need.id, b"");
-        assert!(operation.is_complete());
-        assert!(operation.missing_resources().unwrap().is_empty());
-        assert!(operation.next_priority_need().unwrap().is_none());
-    }
-
-    #[test]
-    fn transition_limit_is_enforced() {
-        let mut registry = Registry::new();
-        registry.register(Loop::SPEC);
-        let limits = DiscoveryLimits {
-            transitions: 3,
-            ..Default::default()
-        };
-        let mut operation = registry.start_with_limits("memory://root", limits);
-        let mut result = Ok(());
-        for _ in 0..5 {
-            let needs = operation.missing_resources().unwrap();
-            if needs.is_empty() {
-                break;
-            }
-            result = operation.provide(ResourceResponse {
-                id: needs[0].id,
-                bytes: vec![],
-            });
-            if result.is_err() {
-                break;
-            }
-        }
-        assert!(matches!(
-            result,
-            Err(DiscoveryError::TransitionLimitExceeded)
-        ));
-    }
-
-    #[test]
-    fn resource_limit_rejects_offending_candidate_instead_of_aborting() {
-        let mut registry = Registry::new();
-        registry.register(A);
-        registry.register(B);
-        registry.register(C);
-        let limits = DiscoveryLimits {
-            resources: 2,
-            ..Default::default()
-        };
-        let mut operation = registry.start_with_limits("memory://root", limits);
-        let needs = operation.missing_resources().unwrap();
-        assert_eq!(needs.len(), 2);
-        assert!(
-            operation
-                .diagnostics
-                .iter()
-                .any(|(id, msg)| id == "c" && msg.message.contains("resource limit"))
-        );
-        for need in needs {
-            operation
-                .provide(ResourceResponse {
-                    id: need.id,
-                    bytes: vec![],
-                })
-                .unwrap();
-        }
-        assert!(operation.is_complete());
-    }
-
-    #[test]
-    fn retained_bytes_limit_is_enforced() {
-        let mut registry = Registry::new();
-        registry.register(ONE_META);
-        let limits = DiscoveryLimits {
-            retained_bytes: 10,
-            ..Default::default()
-        };
-        let mut operation = registry.start_with_limits("memory://root", limits);
-        let needs = operation.missing_resources().unwrap();
-        assert_eq!(needs.len(), 1);
-        let large = vec![0u8; 20];
-        let err = operation
-            .provide(ResourceResponse {
-                id: needs[0].id,
-                bytes: large,
+        operation
+            .provide_failure(ResourceFailure {
+                id: need.id,
+                message: "expected".into(),
             })
+            .unwrap();
+        assert!(operation.finish().unwrap().is_empty());
+    }
+
+    fn repeat(
+        _: &DiscoveryContext<'_>,
+        resource: DiscoveryResource<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        Ok(DiscoveryStep::follow(resource.uri()))
+    }
+
+    const REPEAT: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(repeat)];
+
+    #[test]
+    fn following_the_same_uri_is_rejected() {
+        let mut registry = Registry::new();
+        registry.register(DezoomerSpec::new("repeat", REPEAT));
+        let mut operation = registry.start("memory://repeat");
+        let need = operation.missing_resources().unwrap().pop().unwrap();
+        let error = operation
+            .provide(ResourceResponse::new(need.id, b"again"))
             .unwrap_err();
-        assert_eq!(err, DiscoveryError::MetadataSizeLimitExceeded);
+        assert!(error.to_string().contains("same resource twice"));
+    }
+
+    fn follow_again(
+        context: &DiscoveryContext<'_>,
+        _: DiscoveryResource<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        Ok(DiscoveryStep::follow(format!(
+            "memory://{}",
+            context.resources().count()
+        )))
+    }
+
+    const LOOP: &[DiscoveryRoute] = &[DiscoveryMatch::any().then(follow_again)];
+
+    #[test]
+    fn operation_limits_are_enforced() {
+        let mut registry = Registry::new();
+        registry.register(DezoomerSpec::new("loop", LOOP));
+        let mut transitions = registry.start_with_limits(
+            "memory://start",
+            DiscoveryLimits {
+                transitions: 2,
+                ..Default::default()
+            },
+        );
+        let need = transitions.missing_resources().unwrap().pop().unwrap();
+        transitions
+            .provide(ResourceResponse::new(need.id, []))
+            .unwrap();
+        let need = transitions.missing_resources().unwrap().pop().unwrap();
+        let error = transitions
+            .provide(ResourceResponse::new(need.id, []))
+            .unwrap_err();
+        assert_eq!(error, DiscoveryError::TransitionLimitExceeded);
+
+        let mut resources = registry.start_with_limits(
+            "memory://start",
+            DiscoveryLimits {
+                resources: 1,
+                ..Default::default()
+            },
+        );
+        let need = resources.missing_resources().unwrap().pop().unwrap();
+        assert!(
+            resources
+                .provide(ResourceResponse::new(need.id, []))
+                .is_err()
+        );
+
+        let mut bytes = Registry::new();
+        bytes.register(DezoomerSpec::new("bytes", COMPLETE));
+        let mut bytes = bytes.start_with_limits(
+            "memory://metadata",
+            DiscoveryLimits {
+                retained_bytes: 1,
+                ..Default::default()
+            },
+        );
+        let need = bytes.missing_resources().unwrap().pop().unwrap();
+        assert_eq!(
+            bytes.provide(ResourceResponse::new(need.id, [0, 1])),
+            Err(DiscoveryError::MetadataSizeLimitExceeded)
+        );
+    }
+
+    fn high_start(_: &str) -> Result<Request, DiscoveryError> {
+        Ok(Request::new("memory://high-1"))
+    }
+
+    fn low_start(_: &str) -> Result<Request, DiscoveryError> {
+        Ok(Request::new("memory://low"))
+    }
+
+    fn is_root(uri: &str) -> bool {
+        uri == "memory://root"
+    }
+
+    fn high_next(
+        _: &DiscoveryContext<'_>,
+        _: DiscoveryResource<'_>,
+    ) -> Result<DiscoveryStep, DiscoveryError> {
+        Ok(DiscoveryStep::follow("memory://high-2"))
+    }
+
+    const HIGH: &[DiscoveryRoute] = &[
+        DiscoveryMatch::url_matching(is_root).map_url(high_start),
+        DiscoveryMatch::url_suffix("high-1").then(high_next),
+        DiscoveryMatch::url_suffix("high-2").extract(catalog),
+    ];
+    const LOW: &[DiscoveryRoute] = &[
+        DiscoveryMatch::url_matching(is_root).map_url(low_start),
+        DiscoveryMatch::any().extract(catalog),
+    ];
+
+    #[test]
+    fn priority_stays_depth_first_across_followed_resources() {
+        let mut registry = Registry::new();
+        registry.register(DezoomerSpec::new("high", HIGH));
+        registry.register(DezoomerSpec::new("low", LOW));
+        let mut operation = registry.start("memory://root");
+        assert_eq!(operation.missing_resources().unwrap().len(), 2);
+        let high = operation.next_priority_need().unwrap().unwrap();
+        assert_eq!(high.request.uri, "memory://high-1");
+        operation
+            .provide(ResourceResponse::new(high.id, []))
+            .unwrap();
+        assert_eq!(
+            operation.next_priority_need().unwrap().unwrap().request.uri,
+            "memory://high-2"
+        );
+    }
+
+    #[test]
+    fn media_type_matching_ignores_case_and_parameters() {
+        let request = Request::new("memory://page");
+        let response = ResourceResponse::new(RequestId(0), b"page")
+            .with_content_type("Text/HTML; charset=utf-8");
+        let resource = DiscoveryResource {
+            request: &request,
+            response: &response,
+        };
+        assert!(DiscoveryMatch::media_type(&["text/html"]).matches_resource(resource));
+        assert!(!DiscoveryMatch::media_type(&["text/xml"]).matches_resource(resource));
+    }
+
+    #[test]
+    fn diagnostics_are_displayed_one_per_line() {
+        let error = DiscoveryError::NoCandidateAccepted {
+            diagnostics: vec![
+                ("first".into(), "not first".into()),
+                ("second".into(), "not second".into()),
+            ],
+        };
+        assert_eq!(
+            error.to_string(),
+            "no discovery candidate accepted the input\n - first: not first\n - second: not second"
+        );
     }
 }

--- a/dezoomify-core/src/core/discovery.rs
+++ b/dezoomify-core/src/core/discovery.rs
@@ -20,6 +20,7 @@ pub struct ResourceNeed {
 pub struct ResourceResponse {
     pub id: RequestId,
     pub bytes: Vec<u8>,
+    final_uri: Option<String>,
 }
 impl ResourceResponse {
     #[must_use]
@@ -27,7 +28,15 @@ impl ResourceResponse {
         Self {
             id,
             bytes: bytes.into(),
+            final_uri: None,
         }
+    }
+
+    /// Set the URI reached after the host followed redirects.
+    #[must_use]
+    pub fn with_final_uri(mut self, uri: impl Into<String>) -> Self {
+        self.final_uri = Some(uri.into());
+        self
     }
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -37,7 +46,7 @@ pub struct ResourceFailure {
 }
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum ResourceOutcome {
-    Response(Vec<u8>),
+    Response(ResourceResponse),
     Failure(ResourceFailure),
 }
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -65,12 +74,18 @@ pub enum DiscoveryStep {
 pub struct DiscoveryResource<'a> {
     request: &'a Request,
     bytes: &'a [u8],
+    final_uri: &'a str,
 }
 
 impl<'a> DiscoveryResource<'a> {
     #[must_use]
     pub const fn uri(self) -> &'a str {
         self.request.uri.as_str()
+    }
+    /// The URI after host-level redirects, or [`Self::uri`] when unavailable.
+    #[must_use]
+    pub const fn final_uri(self) -> &'a str {
+        self.final_uri
     }
     #[must_use]
     pub fn bytes(self) -> &'a [u8] {
@@ -89,9 +104,10 @@ impl<'a> DiscoveryContext<'a> {
             .iter()
             .filter_map(|id| self.requests.get(id.0))
             .filter_map(|record| match record.outcome.as_ref()? {
-                ResourceOutcome::Response(bytes) => Some(DiscoveryResource {
+                ResourceOutcome::Response(response) => Some(DiscoveryResource {
                     request: &record.request,
-                    bytes,
+                    bytes: &response.bytes,
+                    final_uri: response.final_uri.as_deref().unwrap_or(&record.request.uri),
                 }),
                 ResourceOutcome::Failure(_) => None,
             })
@@ -293,7 +309,6 @@ pub enum DiscoveryError {
     NotComplete,
     Session(String),
     TransitionLimitExceeded,
-    ResourceLimitExceeded,
     MetadataSizeLimitExceeded,
 }
 
@@ -312,7 +327,6 @@ impl fmt::Display for DiscoveryError {
             Self::NotComplete => f.write_str("discovery is not complete"),
             Self::Session(message) => f.write_str(message),
             Self::TransitionLimitExceeded => f.write_str("discovery transition limit exceeded"),
-            Self::ResourceLimitExceeded => f.write_str("discovery resource limit exceeded"),
             Self::MetadataSizeLimitExceeded => {
                 f.write_str("discovery metadata size limit exceeded")
             }
@@ -418,7 +432,7 @@ impl DiscoveryOperation {
             })
     }
     pub fn provide(&mut self, response: ResourceResponse) -> Result<(), DiscoveryError> {
-        self.provide_outcome(response.id, ResourceOutcome::Response(response.bytes))
+        self.provide_outcome(response.id, ResourceOutcome::Response(response))
     }
     pub fn provide_failure(&mut self, failure: ResourceFailure) -> Result<(), DiscoveryError> {
         self.provide_outcome(failure.id, ResourceOutcome::Failure(failure))
@@ -434,10 +448,10 @@ impl DiscoveryOperation {
         if resource.outcome.is_some() {
             return Err(DiscoveryError::RequestAlreadyProvided(id));
         }
-        if let ResourceOutcome::Response(bytes) = &outcome {
+        if let ResourceOutcome::Response(response) = &outcome {
             self.retained_bytes = self
                 .retained_bytes
-                .checked_add(bytes.len())
+                .checked_add(response.bytes.len())
                 .filter(|total| *total <= self.limits.retained_bytes)
                 .ok_or(DiscoveryError::MetadataSizeLimitExceeded)?;
         }
@@ -522,10 +536,14 @@ impl DiscoveryOperation {
             .as_ref()
             .expect("ready candidate has an outcome")
         {
-            ResourceOutcome::Response(bytes) => dispatch_resource(
+            ResourceOutcome::Response(response) => dispatch_resource(
                 routes,
                 &context,
-                DiscoveryResource { request, bytes },
+                DiscoveryResource {
+                    request,
+                    bytes: &response.bytes,
+                    final_uri: response.final_uri.as_deref().unwrap_or(&request.uri),
+                },
                 "resource did not match any discovery route",
             ),
             ResourceOutcome::Failure(failure) => on_failure.map_or_else(

--- a/dezoomify-core/src/core/mod.rs
+++ b/dezoomify-core/src/core/mod.rs
@@ -23,7 +23,7 @@ pub use model::{
     Request, StableId, TileId, TileRole, TileSpec,
 };
 pub use processing::ProcessingError;
-pub use registry::{Registry, default_registry, registry_for};
+pub use registry::{Registry, builtin_names, default_registry, registry_for};
 pub use tile_plan::{
     Grid, GridCoord, GridRequests, GridTile, Positioned, PositionedTile, TileSource,
     TileSourceError,

--- a/dezoomify-core/src/core/mod.rs
+++ b/dezoomify-core/src/core/mod.rs
@@ -13,8 +13,8 @@ pub mod uri;
 
 pub use adaptive::{DiscoverableGrid, DiscoverableStep, ObservationResult, ProbeContinuation};
 pub use discovery::{
-    DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryFailure, DiscoveryInput,
-    DiscoveryMatch, DiscoveryResource, DiscoveryRoute, DiscoveryStep,
+    DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryMatch, DiscoveryResource,
+    DiscoveryRoute, DiscoveryStep,
 };
 #[cfg(test)]
 pub use discovery::{RequestId, ResourceResponse};

--- a/dezoomify-core/src/core/mod.rs
+++ b/dezoomify-core/src/core/mod.rs
@@ -13,8 +13,8 @@ pub mod uri;
 
 pub use adaptive::{DiscoverableGrid, DiscoverableStep, ObservationResult, ProbeContinuation};
 pub use discovery::{
-    Dezoomer, DezoomerSpec, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput, DiscoveryStep,
-    ResourceOutcome, ResourceRequest, input_resource,
+    DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryFailure, DiscoveryInput,
+    DiscoveryMatch, DiscoveryResource, DiscoveryRoute, DiscoveryStep,
 };
 #[cfg(test)]
 pub use discovery::{RequestId, ResourceResponse};

--- a/dezoomify-core/src/core/registry.rs
+++ b/dezoomify-core/src/core/registry.rs
@@ -1,6 +1,6 @@
 //! Stable registration and precedence policy for pure dezoomers.
 
-use super::discovery::{DezoomerSpec, DiscoveryInput, DiscoveryLimits, DiscoveryOperation};
+use super::discovery::{DezoomerSpec, DiscoveryLimits, DiscoveryOperation};
 use crate::{
     bulk_text, custom_yaml, dzi, generic, google_arts_and_culture, iiif, iipimage, krpano, nypl,
     zoomify,
@@ -39,18 +39,18 @@ impl Registry {
 
     /// Start a discovery operation with candidates in registration order.
     #[must_use]
-    pub fn start(&self, input: impl Into<DiscoveryInput>) -> DiscoveryOperation {
-        self.start_with_limits(input, DiscoveryLimits::default())
+    pub fn start(&self, uri: impl Into<String>) -> DiscoveryOperation {
+        self.start_with_limits(uri, DiscoveryLimits::default())
     }
 
     /// Start independent parser state with explicit operation limits.
     #[must_use]
     pub fn start_with_limits(
         &self,
-        input: impl Into<DiscoveryInput>,
+        uri: impl Into<String>,
         limits: DiscoveryLimits,
     ) -> DiscoveryOperation {
-        DiscoveryOperation::new(&input.into(), &self.specs, limits)
+        DiscoveryOperation::new(uri.into(), &self.specs, limits)
     }
 }
 

--- a/dezoomify-core/src/core/registry.rs
+++ b/dezoomify-core/src/core/registry.rs
@@ -20,6 +20,11 @@ const BUILTINS: &[DezoomerSpec] = &[
     bulk_text::SPEC,
 ];
 
+/// Built-in dezoomer names in candidate priority order.
+pub fn builtin_names() -> impl Iterator<Item = &'static str> {
+    BUILTINS.iter().map(DezoomerSpec::name)
+}
+
 /// An ordered set of dezoomers to try. Earlier registrations have priority.
 #[derive(Default, Clone)]
 pub struct Registry {
@@ -87,12 +92,12 @@ mod tests {
 
     #[test]
     fn every_builtin_name_resolves_to_a_single_program() {
-        for builtin in BUILTINS {
-            let registry = registry_for(builtin.name()).unwrap_or_else(|| {
-                panic!("built-in `{}` must resolve", builtin.name());
+        for name in builtin_names() {
+            let registry = registry_for(name).unwrap_or_else(|| {
+                panic!("built-in `{name}` must resolve");
             });
             assert_eq!(registry.specs.len(), 1);
-            assert_eq!(registry.specs[0].name(), builtin.name());
+            assert_eq!(registry.specs[0].name(), name);
         }
         assert!(registry_for("nope").is_none());
     }

--- a/dezoomify-core/src/custom_yaml/mod.rs
+++ b/dezoomify-core/src/custom_yaml/mod.rs
@@ -14,9 +14,8 @@ use crate::default_headers;
 mod tile_set;
 mod variable;
 
-pub const SPEC: DezoomerSpec =
-    DezoomerSpec::new("custom", &[DiscoveryMatch::any().extract(catalog)])
-        .recognizing(|uri| uri.ends_with("tiles.yaml"), "not a tiles.yaml file");
+pub const SPEC: DezoomerSpec = DezoomerSpec::new("custom", &[DiscoveryMatch::Any.extract(catalog)])
+    .recognizing(|uri| uri.ends_with("tiles.yaml"), "not a tiles.yaml file");
 
 fn catalog(_: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
     catalog_from_yaml(bytes)

--- a/dezoomify-core/src/custom_yaml/mod.rs
+++ b/dezoomify-core/src/custom_yaml/mod.rs
@@ -6,18 +6,21 @@ use serde::Deserialize;
 
 use crate::Vec2d;
 use crate::core::{
-    CatalogEntry, DezoomerSpec, DiscoveryError, ImageCatalog, ImageDescriptor, LevelDescriptor,
-    Positioned, ProcessingRecipe, Request, StableId, TileSourceError, input_resource,
+    CatalogEntry, DezoomerSpec, DiscoveryError, DiscoveryMatch, ImageCatalog, ImageDescriptor,
+    LevelDescriptor, Positioned, ProcessingRecipe, Request, StableId, TileSourceError,
 };
 use crate::default_headers;
 
 mod tile_set;
 mod variable;
 
-pub const SPEC: DezoomerSpec = DezoomerSpec::routed("custom", input_resource, |_, bytes| {
+pub const SPEC: DezoomerSpec =
+    DezoomerSpec::new("custom", &[DiscoveryMatch::any().extract(catalog)])
+        .recognizing(|uri| uri.ends_with("tiles.yaml"), "not a tiles.yaml file");
+
+fn catalog(_: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
     catalog_from_yaml(bytes)
-})
-.recognizing(|uri| uri.ends_with("tiles.yaml"), "not a tiles.yaml file");
+}
 
 #[derive(Deserialize)]
 struct CustomYamlTiles {

--- a/dezoomify-core/src/dzi/mod.rs
+++ b/dezoomify-core/src/dzi/mod.rs
@@ -21,8 +21,8 @@ static TILE_URL: LazyLock<Regex> = LazyLock::new(|| {
 pub const SPEC: DezoomerSpec = DezoomerSpec::new(
     "deepzoom",
     &[
-        DiscoveryMatch::url_matching(is_tile_url).map_url(tile_metadata),
-        DiscoveryMatch::any().extract(load_catalog),
+        DiscoveryMatch::UrlPredicate(is_tile_url).map_url(tile_metadata),
+        DiscoveryMatch::Any.extract(load_catalog),
     ],
 )
 .preferring(|uri| uri.contains(".dzi") || uri.contains("_files/"));

--- a/dezoomify-core/src/dzi/mod.rs
+++ b/dezoomify-core/src/dzi/mod.rs
@@ -1,31 +1,41 @@
 //! Pure discovery for Deep Zoom Image descriptors.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use dzi_file::DziFile;
 use regex::Regex;
 
 use crate::Vec2d;
 use crate::core::{
-    CatalogEntry, DezoomerSpec, DiscoveryError, Grid, ImageCatalog, ImageDescriptor,
-    LevelDescriptor, Request, ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryError, DiscoveryMatch, Grid, ImageCatalog,
+    ImageDescriptor, LevelDescriptor, Request, StableId,
 };
 use crate::json_utils::all_json;
 
 mod dzi_file;
 
-pub const SPEC: DezoomerSpec =
-    DezoomerSpec::routed("deepzoom", |uri| Ok(metadata_request(uri)), load_catalog)
-        .preferring(|uri| uri.contains(".dzi") || uri.contains("_files/"));
+static TILE_URL: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new("_files/\\d+/\\d+_\\d+\\.(jpe?g|png)$").expect("constant DZI tile pattern")
+});
 
-fn metadata_request(input: &str) -> ResourceRequest {
-    let tile =
-        Regex::new("_files/\\d+/\\d+_\\d+\\.(jpe?g|png)$").expect("constant DZI tile pattern");
-    let uri = tile.find(input).map_or_else(
-        || input.to_owned(),
-        |matched| format!("{}.dzi", &input[..matched.start()]),
-    );
-    ResourceRequest::new(uri)
+pub const SPEC: DezoomerSpec = DezoomerSpec::new(
+    "deepzoom",
+    &[
+        DiscoveryMatch::url_matching(is_tile_url).map_url(tile_metadata),
+        DiscoveryMatch::any().extract(load_catalog),
+    ],
+)
+.preferring(|uri| uri.contains(".dzi") || uri.contains("_files/"));
+
+fn is_tile_url(input: &str) -> bool {
+    TILE_URL.is_match(input)
+}
+
+fn tile_metadata(input: &str) -> Result<Request, DiscoveryError> {
+    let matched = TILE_URL
+        .find(input)
+        .ok_or_else(|| DiscoveryError::Session("not a DZI tile URL".into()))?;
+    Ok(Request::new(format!("{}.dzi", &input[..matched.start()])))
 }
 
 fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryError> {

--- a/dezoomify-core/src/google_arts_and_culture/mod.rs
+++ b/dezoomify-core/src/google_arts_and_culture/mod.rs
@@ -1,11 +1,10 @@
 //! Pure Google Arts & Culture two-stage discovery.
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerSpec, DiscoveryError, DiscoveryInput, DiscoveryStep, Grid,
-    ImageCatalog, ImageDescriptor, LevelDescriptor, ProcessingRecipe, Request, ResourceOutcome,
-    ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryMatch,
+    DiscoveryResource, DiscoveryRoute, DiscoveryStep, Grid, ImageCatalog, ImageDescriptor,
+    LevelDescriptor, ProcessingRecipe, Request, StableId,
 };
 use std::sync::Arc;
 use tile_info::{PageInfo, TileInfo};
@@ -13,58 +12,42 @@ pub(crate) mod decryption;
 mod tile_info;
 mod url;
 
-pub const SPEC: DezoomerSpec = DezoomerSpec::stateful("google_arts_and_culture", start)
+const ROUTES: &[DiscoveryRoute] = &[
+    DiscoveryMatch::url_suffix("=g").then(parse_tile_information),
+    DiscoveryMatch::any().then(parse_page),
+];
+
+pub const SPEC: DezoomerSpec = DezoomerSpec::new("google_arts_and_culture", ROUTES)
     .recognizing(is_google_arts_url, "not a Google Arts & Culture URL");
 
 fn is_google_arts_url(uri: &str) -> bool {
-    uri.contains("artsandculture.google.com") || uri.contains("g.co/arts/") || uri.ends_with("=g")
+    uri.contains("artsandculture.google.com") || uri.contains("g.co/arts/")
 }
 
-pub struct Gap {
-    uri: String,
-    page: Option<Arc<PageInfo>>,
-    requested: bool,
+fn parse_page(
+    _context: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let source = std::str::from_utf8(resource.bytes())
+        .map_err(|error| DiscoveryError::Session(error.to_string()))?;
+    let page = source
+        .parse::<PageInfo>()
+        .map_err(|error| DiscoveryError::Session(error.to_string()))?;
+    Ok(DiscoveryStep::Follow(Request::new(page.tile_info_url())))
 }
 
-impl Dezoomer for Gap {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if !self.requested => {
-                self.requested = true;
-                Ok(DiscoveryStep::Need(ResourceRequest::new(self.uri.clone())))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response))
-                if self.page.is_none() =>
-            {
-                let source = std::str::from_utf8(&response.bytes)
-                    .map_err(|error| DiscoveryError::Session(error.to_string()))?;
-                let page: PageInfo = source
-                    .parse::<PageInfo>()
-                    .map_err(|error| DiscoveryError::Session(error.to_string()))?;
-                let next = page.tile_info_url();
-                self.page = Some(Arc::new(page));
-                Ok(DiscoveryStep::Need(ResourceRequest::new(next)))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => {
-                catalog(self.page.as_ref().expect("page set"), &response.bytes)
-                    .map(DiscoveryStep::Complete)
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                Err(DiscoveryError::Session(failure.message.clone()))
-            }
-            DiscoveryEvent::Start => {
-                Err(DiscoveryError::Session("GAP session started twice".into()))
-            }
-        }
-    }
-}
-
-fn start(input: &DiscoveryInput) -> Box<dyn Dezoomer> {
-    Box::new(Gap {
-        uri: input.uri.clone(),
-        page: None,
-        requested: false,
-    })
+fn parse_tile_information(
+    context: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let page = context
+        .resources()
+        .map(DiscoveryResource::bytes)
+        .filter_map(|bytes| std::str::from_utf8(bytes).ok())
+        .find_map(|source| source.parse::<PageInfo>().ok())
+        .map(Arc::new)
+        .ok_or_else(|| DiscoveryError::Session("Google Arts page metadata is missing".into()))?;
+    catalog(&page, resource.bytes()).map(DiscoveryStep::Complete)
 }
 
 fn catalog(page: &Arc<PageInfo>, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
@@ -119,63 +102,55 @@ fn catalog(page: &Arc<PageInfo>, bytes: &[u8]) -> Result<ImageCatalog, Discovery
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{RequestId, ResourceResponse, TileSource};
-
-    fn response(bytes: &[u8]) -> ResourceOutcome {
-        ResourceOutcome::Response(ResourceResponse {
-            id: RequestId(0),
-            bytes: bytes.to_vec(),
-        })
-    }
+    use crate::core::{ResourceResponse, TileSource};
 
     fn fixture_catalog() -> ImageCatalog {
-        let input = DiscoveryInput::from("https://artsandculture.google.com/asset/test");
-        let mut session = start(&input);
-        session.advance(DiscoveryEvent::Start).unwrap();
-        let page = response(include_bytes!(
-            "../../testdata/google_arts_and_culture/page_source.html"
-        ));
-        session.advance(DiscoveryEvent::Resource(&page)).unwrap();
-        let tile_info = response(include_bytes!(
-            "../../testdata/google_arts_and_culture/tile_info.xml"
-        ));
-        let DiscoveryStep::Complete(catalog) = session
-            .advance(DiscoveryEvent::Resource(&tile_info))
-            .unwrap()
-        else {
-            panic!("fixture tile information must complete discovery");
-        };
-        catalog
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://artsandculture.google.com/asset/test");
+        let page = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(
+                page.id,
+                include_bytes!("../../testdata/google_arts_and_culture/page_source.html"),
+            ))
+            .unwrap();
+        let tile_info = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(
+                tile_info.id,
+                include_bytes!("../../testdata/google_arts_and_culture/tile_info.xml"),
+            ))
+            .unwrap();
+        operation.finish().unwrap()
     }
 
     #[test]
     fn discovers_fixture_as_five_replayable_levels() {
-        let input = DiscoveryInput::from("https://artsandculture.google.com/asset/test");
-        let mut session = start(&input);
-        let DiscoveryStep::Need(page) = session.advance(DiscoveryEvent::Start).unwrap() else {
-            panic!("Google Arts discovery must request the page");
-        };
-        assert_eq!(page.request.uri, input.uri);
-
-        let page = response(include_bytes!(
-            "../../testdata/google_arts_and_culture/page_source.html"
-        ));
-        let DiscoveryStep::Need(tile_info) =
-            session.advance(DiscoveryEvent::Resource(&page)).unwrap()
-        else {
-            panic!("the page must lead to tile information");
-        };
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let input = "https://artsandculture.google.com/asset/test";
+        let mut operation = registry.start(input);
+        let page = operation.missing_resources().unwrap().pop().unwrap();
+        assert_eq!(page.request.uri, input);
+        operation
+            .provide(
+                ResourceResponse::new(
+                    page.id,
+                    include_bytes!("../../testdata/google_arts_and_culture/page_source.html"),
+                )
+                .with_content_type("text/html; charset=utf-8"),
+            )
+            .unwrap();
+        let tile_info = operation.missing_resources().unwrap().pop().unwrap();
         assert!(tile_info.request.uri.ends_with("=g"));
-
-        let tile_info = response(include_bytes!(
-            "../../testdata/google_arts_and_culture/tile_info.xml"
-        ));
-        let DiscoveryStep::Complete(catalog) = session
-            .advance(DiscoveryEvent::Resource(&tile_info))
-            .unwrap()
-        else {
-            panic!("tile information must complete discovery");
-        };
+        operation
+            .provide(ResourceResponse::new(
+                tile_info.id,
+                include_bytes!("../../testdata/google_arts_and_culture/tile_info.xml"),
+            ))
+            .unwrap();
+        let catalog = operation.finish().unwrap();
         let [CatalogEntry::Ready(image)] = catalog.entries() else {
             panic!("Google Arts produces one ready image");
         };
@@ -212,6 +187,17 @@ mod tests {
         let mut registry = crate::core::Registry::new();
         registry.register(SPEC);
         let mut operation = registry.start("https://example.com/test");
+        assert!(matches!(
+            operation.missing_resources(),
+            Err(DiscoveryError::NoCandidateAccepted { .. })
+        ));
+    }
+
+    #[test]
+    fn does_not_advertise_tile_metadata_without_the_required_page_context() {
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://lh3.googleusercontent.com/image-id=g");
         assert!(matches!(
             operation.missing_resources(),
             Err(DiscoveryError::NoCandidateAccepted { .. })
@@ -258,20 +244,24 @@ mod tests {
     }
 
     #[test]
-    fn invalid_tile_information_is_reported_as_a_session_error() {
-        let input = DiscoveryInput::from("https://artsandculture.google.com/asset/test");
-        let mut session = start(&input);
-        session.advance(DiscoveryEvent::Start).unwrap();
-        let page = response(include_bytes!(
-            "../../testdata/google_arts_and_culture/page_source.html"
-        ));
-        session.advance(DiscoveryEvent::Resource(&page)).unwrap();
-        let invalid = response(b"<invalid>not a tile info</invalid>");
-        let Err(DiscoveryError::Session(message)) =
-            session.advance(DiscoveryEvent::Resource(&invalid))
-        else {
-            panic!("invalid tile XML must be rejected by the pure session");
-        };
-        assert!(message.contains("invalid Google Arts tile XML"));
+    fn invalid_tile_information_is_reported_as_a_parser_error() {
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://artsandculture.google.com/asset/test");
+        let page = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(
+                page.id,
+                include_bytes!("../../testdata/google_arts_and_culture/page_source.html"),
+            ))
+            .unwrap();
+        let tile_info = operation.missing_resources().unwrap().pop().unwrap();
+        let error = operation
+            .provide(ResourceResponse::new(
+                tile_info.id,
+                b"<invalid>not a tile info</invalid>",
+            ))
+            .unwrap_err();
+        assert!(error.to_string().contains("invalid Google Arts tile XML"));
     }
 }

--- a/dezoomify-core/src/google_arts_and_culture/mod.rs
+++ b/dezoomify-core/src/google_arts_and_culture/mod.rs
@@ -13,8 +13,8 @@ mod tile_info;
 mod url;
 
 const ROUTES: &[DiscoveryRoute] = &[
-    DiscoveryMatch::url_suffix("=g").then(parse_tile_information),
-    DiscoveryMatch::any().then(parse_page),
+    DiscoveryMatch::UrlSuffix("=g").then(parse_tile_information),
+    DiscoveryMatch::Any.then(parse_page),
 ];
 
 pub const SPEC: DezoomerSpec = DezoomerSpec::new("google_arts_and_culture", ROUTES)
@@ -134,13 +134,10 @@ mod tests {
         let page = operation.missing_resources().unwrap().pop().unwrap();
         assert_eq!(page.request.uri, input);
         operation
-            .provide(
-                ResourceResponse::new(
-                    page.id,
-                    include_bytes!("../../testdata/google_arts_and_culture/page_source.html"),
-                )
-                .with_content_type("text/html; charset=utf-8"),
-            )
+            .provide(ResourceResponse::new(
+                page.id,
+                include_bytes!("../../testdata/google_arts_and_culture/page_source.html"),
+            ))
             .unwrap();
         let tile_info = operation.missing_resources().unwrap().pop().unwrap();
         assert!(tile_info.request.uri.ends_with("=g"));

--- a/dezoomify-core/src/iiif/mod.rs
+++ b/dezoomify-core/src/iiif/mod.rs
@@ -580,15 +580,15 @@ fn discovery_requests_metadata_then_returns_normalized_replayable_levels() {
     let need = operation.missing_resources().unwrap().pop().unwrap();
     assert_eq!(need.request.uri, "https://example.com/image/info.json");
     operation
-        .provide(crate::core::ResourceResponse {
-            id: need.id,
-            bytes: br#"{
+        .provide(crate::core::ResourceResponse::new(
+            need.id,
+            br#"{
           "type":"ImageService3", "id":"https://images.example/item",
           "width":1000, "height":1500,
           "tiles":[{"width":512,"height":512,"scaleFactors":[1,2,4]}]
         }"#
-            .to_vec(),
-        })
+            .as_slice(),
+        ))
         .unwrap();
     let catalog = operation.finish().unwrap();
     let [CatalogEntry::Ready(image)] = catalog.entries() else {

--- a/dezoomify-core/src/iiif/mod.rs
+++ b/dezoomify-core/src/iiif/mod.rs
@@ -18,7 +18,7 @@ pub mod tile_info;
 mod title_tests;
 
 /// IIIF dezoomer. See <https://iiif.io/>.
-pub const SPEC: DezoomerSpec = DezoomerSpec::new("iiif", &[DiscoveryMatch::any().extract(catalog)])
+pub const SPEC: DezoomerSpec = DezoomerSpec::new("iiif", &[DiscoveryMatch::Any.extract(catalog)])
     .preferring(|uri| {
         uri.contains("info.json") || uri.contains("iiif") || uri.contains("manifest.json")
     });
@@ -588,7 +588,6 @@ fn discovery_requests_metadata_then_returns_normalized_replayable_levels() {
           "tiles":[{"width":512,"height":512,"scaleFactors":[1,2,4]}]
         }"#
             .to_vec(),
-            content_type: None,
         })
         .unwrap();
     let catalog = operation.finish().unwrap();

--- a/dezoomify-core/src/iiif/mod.rs
+++ b/dezoomify-core/src/iiif/mod.rs
@@ -5,8 +5,8 @@ use tile_info::ImageInfo;
 
 use crate::Vec2d;
 use crate::core::{
-    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryError, Grid, GridRequests, GridTile,
-    ImageCatalog, ImageDescriptor, LevelDescriptor, Request, StableId, input_resource,
+    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryError, DiscoveryMatch, Grid, GridRequests,
+    GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor, Request, StableId,
 };
 use crate::iiif::tile_info::TileSizeFormat;
 use crate::json_utils::all_json;
@@ -18,8 +18,8 @@ pub mod tile_info;
 mod title_tests;
 
 /// IIIF dezoomer. See <https://iiif.io/>.
-pub const SPEC: DezoomerSpec =
-    DezoomerSpec::routed("iiif", input_resource, catalog).preferring(|uri| {
+pub const SPEC: DezoomerSpec = DezoomerSpec::new("iiif", &[DiscoveryMatch::any().extract(catalog)])
+    .preferring(|uri| {
         uri.contains("info.json") || uri.contains("iiif") || uri.contains("manifest.json")
     });
 
@@ -588,6 +588,7 @@ fn discovery_requests_metadata_then_returns_normalized_replayable_levels() {
           "tiles":[{"width":512,"height":512,"scaleFactors":[1,2,4]}]
         }"#
             .to_vec(),
+            content_type: None,
         })
         .unwrap();
     let catalog = operation.finish().unwrap();

--- a/dezoomify-core/src/iipimage/mod.rs
+++ b/dezoomify-core/src/iipimage/mod.rs
@@ -5,35 +5,39 @@ use std::sync::Arc;
 
 use crate::Vec2d;
 use crate::core::{
-    CatalogEntry, DezoomerSpec, DiscoveryError, Grid, ImageCatalog, ImageDescriptor,
-    LevelDescriptor, Request, ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryError, DiscoveryMatch, Grid, ImageCatalog,
+    ImageDescriptor, LevelDescriptor, Request, StableId,
 };
 
 const META: &str = "&OBJ=Max-size&OBJ=Tile-size&OBJ=Resolution-number";
 
-pub const SPEC: DezoomerSpec =
-    DezoomerSpec::routed("iipimage", |uri| Ok(metadata_request(uri)), catalog)
-        .recognizing(is_iip, "not an IIPImage URL")
-        .preferring(|uri| uri.to_ascii_lowercase().contains("?fif"));
+pub const SPEC: DezoomerSpec = DezoomerSpec::new(
+    "iipimage",
+    &[
+        DiscoveryMatch::url_matching(needs_metadata).map_url(metadata_url),
+        DiscoveryMatch::any().extract(catalog),
+    ],
+)
+.recognizing(is_iip, "not an IIPImage URL")
+.preferring(|uri| uri.to_ascii_lowercase().contains("?fif"));
 
 fn is_iip(uri: &str) -> bool {
     uri.ends_with(META) || uri.to_ascii_lowercase().contains("?fif")
 }
 
-fn metadata_request(input: &str) -> ResourceRequest {
-    let uri = if input.ends_with(META) {
-        input.to_owned()
-    } else {
-        format!(
-            "{}{}",
-            input
-                .chars()
-                .take_while(|character| *character != '&')
-                .collect::<String>(),
-            META
-        )
-    };
-    ResourceRequest::new(uri)
+fn needs_metadata(uri: &str) -> bool {
+    !uri.ends_with(META)
+}
+
+fn metadata_url(input: &str) -> Result<Request, DiscoveryError> {
+    Ok(Request::new(format!(
+        "{}{}",
+        input
+            .chars()
+            .take_while(|character| *character != '&')
+            .collect::<String>(),
+        META
+    )))
 }
 
 fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
@@ -128,7 +132,7 @@ mod tests {
     fn lowercase_fif_urls_request_canonical_metadata() {
         let uri = "https://publications-images.artic.edu/fcgi-bin/iipsrv.fcgi?fif=osci/Renoir_11/Color_Corrected/G39094sm2.ptif&jtl=4,11";
         assert_eq!(
-            metadata_request(uri).request.uri,
+            metadata_url(uri).unwrap().uri,
             "https://publications-images.artic.edu/fcgi-bin/iipsrv.fcgi?fif=osci/Renoir_11/Color_Corrected/G39094sm2.ptif&OBJ=Max-size&OBJ=Tile-size&OBJ=Resolution-number"
         );
     }

--- a/dezoomify-core/src/iipimage/mod.rs
+++ b/dezoomify-core/src/iipimage/mod.rs
@@ -14,8 +14,8 @@ const META: &str = "&OBJ=Max-size&OBJ=Tile-size&OBJ=Resolution-number";
 pub const SPEC: DezoomerSpec = DezoomerSpec::new(
     "iipimage",
     &[
-        DiscoveryMatch::url_matching(needs_metadata).map_url(metadata_url),
-        DiscoveryMatch::any().extract(catalog),
+        DiscoveryMatch::UrlPredicate(needs_metadata).map_url(metadata_url),
+        DiscoveryMatch::Any.extract(catalog),
     ],
 )
 .recognizing(is_iip, "not an IIPImage URL")
@@ -29,6 +29,7 @@ fn needs_metadata(uri: &str) -> bool {
     !uri.ends_with(META)
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn metadata_url(input: &str) -> Result<Request, DiscoveryError> {
     Ok(Request::new(format!(
         "{}{}",

--- a/dezoomify-core/src/krpano/mod.rs
+++ b/dezoomify-core/src/krpano/mod.rs
@@ -12,272 +12,189 @@ use krpano_metadata::{KrpanoMetadata, XY, all_sides};
 use log::{debug, info, warn};
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::resolve_relative;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerSpec, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor,
-    Request, ResourceOutcome, ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryFailure, DiscoveryMatch,
+    DiscoveryResource, DiscoveryRoute, DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog,
+    ImageDescriptor, LevelDescriptor, Request, StableId,
 };
 use crate::krpano::krpano_metadata::{ImageInfo, LevelDesc};
 use crate::template::Template;
 
 mod krpano_metadata;
 
-pub const SPEC: DezoomerSpec =
-    DezoomerSpec::stateful("krpano", start).preferring(|uri| uri.contains("tiles.xml"));
+const ROUTES: &[DiscoveryRoute] = &[
+    DiscoveryMatch::content_matching(looks_like_xml_or_encrypted).then(handle_xml),
+    DiscoveryMatch::content_matching(looks_like_viewer_js).then(handle_viewer_js),
+    DiscoveryMatch::content_matching(looks_like_krpano_html).then(handle_html),
+    DiscoveryMatch::url_matching(is_javascript_uri).then(handle_viewer_js),
+];
 
-/// The krpano metadata dezoomer.
-///
-/// The dezoomer owns only parser state. The application supplies the requested
-/// HTML, XML, and viewer-script bytes through [`Dezoomer::advance`].
-pub struct Krpano {
-    input_uri: String,
-    state: SessionState,
-}
+pub const SPEC: DezoomerSpec = DezoomerSpec::new("krpano", ROUTES)
+    .on_failure(handle_failure)
+    .preferring(|uri| uri.contains("tiles.xml"));
 
-enum SessionState {
-    Initial,
-    WaitingInitial,
-    NeedXml {
-        xml_uri: String,
-        viewer_js: Vec<u8>,
-        remaining_js_uris: Vec<String>,
-    },
-    NeedViewerJs {
-        xml_uri: String,
-        xml_contents: Vec<u8>,
-        remaining_js_uris: Vec<String>,
-    },
-    Complete,
-}
-
-impl Dezoomer for Krpano {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if matches!(self.state, SessionState::Initial) => {
-                self.state = SessionState::WaitingInitial;
-                Ok(need(&self.input_uri))
-            }
-            DiscoveryEvent::Start => Err(DiscoveryError::Session(
-                "krpano session started twice".into(),
-            )),
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                self.handle_failure(failure.message.as_str())
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => {
-                self.handle_response(&response.bytes)
-            }
-        }
+fn handle_html(
+    context: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    if find_xml(context).is_some() {
+        return handle_viewer_js(context, resource);
     }
+    let html = String::from_utf8_lossy(resource.bytes());
+    let xml_uri = extract_xml_from_embedpano(&html).map_or_else(
+        || sibling_uri(resource.uri(), "tour.xml"),
+        |reference| resolve_relative(resource.uri(), &reference),
+    );
+    debug!("krpano: resolved XML URI {xml_uri}");
+    Ok(need(&xml_uri))
 }
 
-fn start(input: &DiscoveryInput) -> Box<dyn Dezoomer> {
-    Box::new(Krpano {
-        input_uri: input.uri.clone(),
-        state: SessionState::Initial,
-    })
-}
+fn handle_xml(
+    context: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let contents = resource.bytes();
+    if !is_encrypted_xml(contents) {
+        return complete(resource.uri(), contents);
+    }
 
-impl Krpano {
-    fn handle_failure(&mut self, message: &str) -> Result<DiscoveryStep, DiscoveryError> {
-        debug!("krpano: resource failure: {message}");
-        let state = std::mem::replace(&mut self.state, SessionState::Complete);
-        match state {
-            SessionState::NeedViewerJs {
-                xml_uri,
-                xml_contents,
-                mut remaining_js_uris,
-            } => {
-                warn!("krpano: viewer JS fetch failed for {xml_uri}: {message}");
-                if let Some(next_js_uri) = next_js_candidate(&mut remaining_js_uris) {
-                    debug!("krpano: trying next viewer JS candidate {next_js_uri}");
-                    self.state = SessionState::NeedViewerJs {
-                        xml_uri,
-                        xml_contents,
-                        remaining_js_uris,
-                    };
-                    Ok(need(&next_js_uri))
-                } else {
-                    Err(DiscoveryError::Session(format!(
-                        "failed to download krpano viewer script: {message}"
-                    )))
-                }
-            }
-            SessionState::Initial | SessionState::WaitingInitial | SessionState::NeedXml { .. } => {
+    let viewer_js = context
+        .resources()
+        .filter(|candidate| candidate.uri() != resource.uri())
+        .filter(|candidate| is_javascript_resource(*candidate))
+        .filter_map(|candidate| extract_viewer_js(candidate.bytes()))
+        .next_back();
+    match decrypt_xml(contents, viewer_js.as_deref()) {
+        Ok(decrypted) => complete(resource.uri(), &decrypted),
+        Err(error) => next_viewer(context, resource, resource.uri()).map_or_else(
+            || {
                 Err(DiscoveryError::Session(format!(
-                    "failed to download krpano metadata: {message}"
+                    "unable to decrypt krpano XML: {error}"
                 )))
-            }
-            SessionState::Complete => Err(DiscoveryError::Session(
-                "krpano session has already completed".into(),
-            )),
-        }
+            },
+            |uri| Ok(need(&uri)),
+        ),
     }
+}
 
-    fn handle_response(&mut self, contents: &[u8]) -> Result<DiscoveryStep, DiscoveryError> {
-        let state = std::mem::replace(&mut self.state, SessionState::Complete);
-        match state {
-            SessionState::WaitingInitial => self.handle_initial(contents),
-            SessionState::Initial => Err(DiscoveryError::Session(
-                "krpano session received a resource before it started".into(),
-            )),
-            SessionState::NeedXml {
-                xml_uri,
-                viewer_js,
-                remaining_js_uris,
-            } => self.handle_xml(contents, xml_uri, &viewer_js, remaining_js_uris),
-            SessionState::NeedViewerJs {
-                xml_uri,
-                xml_contents,
-                remaining_js_uris,
-            } => self.handle_viewer_js(contents, xml_uri, xml_contents, remaining_js_uris),
-            SessionState::Complete => Err(DiscoveryError::Session(
-                "krpano session has already completed".into(),
-            )),
+fn handle_viewer_js(
+    context: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let Some(xml) = find_xml(context) else {
+        if extract_viewer_js(resource.bytes()).is_none() {
+            return Err(DiscoveryError::Session(
+                "not krpano viewer JavaScript".into(),
+            ));
         }
+        return Ok(need(&sibling_uri(resource.uri(), "tour.xml")));
+    };
+    let viewer_js =
+        extract_viewer_js(resource.bytes()).unwrap_or_else(|| resource.bytes().to_vec());
+    match decrypt_xml(xml.bytes(), Some(&viewer_js)) {
+        Ok(decrypted) => {
+            info!("krpano: successfully decrypted XML using viewer JS");
+            complete(xml.uri(), &decrypted)
+        }
+        Err(error) => next_viewer(context, resource, xml.uri()).map_or_else(
+            || {
+                Err(DiscoveryError::Session(format!(
+                    "unable to decrypt krpano XML: {error}"
+                )))
+            },
+            |uri| Ok(need(&uri)),
+        ),
     }
+}
 
-    fn handle_initial(&mut self, contents: &[u8]) -> Result<DiscoveryStep, DiscoveryError> {
-        debug!("krpano: handling initial response for {}", self.input_uri);
-        if !looks_like_krpano_xml(contents) && looks_like_viewer_js(contents) {
-            debug!("krpano: initial response looks like viewer JS, requesting tour.xml sibling");
-            let xml_uri = sibling_uri(&self.input_uri, "tour.xml");
-            self.state = SessionState::NeedXml {
-                xml_uri: xml_uri.clone(),
-                viewer_js: contents.to_vec(),
-                remaining_js_uris: Vec::new(),
-            };
-            return Ok(need(&xml_uri));
+fn handle_failure(
+    context: &DiscoveryContext<'_>,
+    resource: DiscoveryFailure<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let message = resource.failure().message.as_str();
+    debug!("krpano: resource failure: {message}");
+    if let Some(xml) = find_xml(context) {
+        warn!(
+            "krpano: viewer JS fetch failed for {}: {message}",
+            xml.uri()
+        );
+        if let Some(uri) = next_viewer_after_failure(context, resource.uri(), xml.uri()) {
+            return Ok(need(&uri));
         }
-
-        if !looks_like_krpano_xml(contents) && looks_like_krpano_html(contents) {
-            debug!("krpano: initial response looks like HTML, extracting XML and JS candidates");
-            let html = String::from_utf8_lossy(contents);
-            let remaining_js_uris = extract_js_candidates_from_html(&html, &self.input_uri);
-            debug!(
-                "krpano: found {} JS candidates in HTML",
-                remaining_js_uris.len()
-            );
-            let xml_uri = extract_xml_from_embedpano(&html).map_or_else(
-                || sibling_uri(&self.input_uri, "tour.xml"),
-                |reference| resolve_relative(&self.input_uri, &reference),
-            );
-            debug!("krpano: resolved XML URI {xml_uri}");
-            self.state = SessionState::NeedXml {
-                xml_uri: xml_uri.clone(),
-                viewer_js: Vec::new(),
-                remaining_js_uris,
-            };
-            return Ok(need(&xml_uri));
-        }
-
-        if is_encrypted_xml(contents) {
-            debug!("krpano: initial XML is encrypted, attempting decryption without viewer JS");
-            if let Ok(decrypted) = decrypt_xml(contents, None) {
-                debug!("krpano: decrypted XML without viewer JS");
-                return self.complete(&self.input_uri.clone(), &decrypted);
-            }
-            debug!("krpano: decryption without viewer JS failed, trying viewer JS candidates");
-            let mut candidates = viewer_js_candidates_for_xml(&self.input_uri);
-            let viewer_uri = next_js_candidate(&mut candidates)
-                .unwrap_or_else(|| sibling_uri(&self.input_uri, "tour.js"));
-            self.state = SessionState::NeedViewerJs {
-                xml_uri: self.input_uri.clone(),
-                xml_contents: contents.to_vec(),
-                remaining_js_uris: candidates,
-            };
-            return Ok(need(&viewer_uri));
-        }
-
-        if looks_like_krpano_xml(contents) {
-            debug!("krpano: initial response is plain XML, completing");
-            return self.complete(&self.input_uri.clone(), contents);
-        }
-
-        Ok(DiscoveryStep::Reject(DiscoveryDiagnostic::from(
-            "not krpano HTML, viewer JavaScript, or XML metadata",
-        )))
+        return Err(DiscoveryError::Session(format!(
+            "failed to download krpano viewer script: {message}"
+        )));
     }
+    Err(DiscoveryError::Session(format!(
+        "failed to download krpano metadata: {message}"
+    )))
+}
 
-    fn handle_xml(
-        &mut self,
-        contents: &[u8],
-        xml_uri: String,
-        viewer_js: &[u8],
-        mut remaining_js_uris: Vec<String>,
-    ) -> Result<DiscoveryStep, DiscoveryError> {
-        if !is_encrypted_xml(contents) {
-            debug!("krpano: XML at {xml_uri} is not encrypted, completing");
-            return self.complete(&xml_uri, contents);
-        }
-        debug!("krpano: XML at {xml_uri} is encrypted, attempting decryption");
+fn find_xml<'a>(context: &DiscoveryContext<'a>) -> Option<DiscoveryResource<'a>> {
+    context
+        .resources()
+        .rev()
+        .find(|resource| looks_like_xml_or_encrypted(resource.bytes()))
+}
 
-        match decrypt_xml(contents, (!viewer_js.is_empty()).then_some(viewer_js)) {
-            Ok(decrypted) => {
-                debug!("krpano: successfully decrypted XML at {xml_uri}");
-                self.complete(&xml_uri, &decrypted)
-            }
-            Err(error) => {
-                warn!("krpano: failed to decrypt XML at {xml_uri}: {error}");
-                let Some(viewer_uri) = next_js_candidate(&mut remaining_js_uris) else {
-                    return Err(DiscoveryError::Session(format!(
-                        "unable to decrypt krpano XML: {error}"
-                    )));
-                };
-                debug!("krpano: trying next viewer JS candidate {viewer_uri}");
-                self.state = SessionState::NeedViewerJs {
-                    xml_uri,
-                    xml_contents: contents.to_vec(),
-                    remaining_js_uris,
-                };
-                Ok(need(&viewer_uri))
-            }
-        }
-    }
+fn next_viewer(
+    context: &DiscoveryContext<'_>,
+    current: DiscoveryResource<'_>,
+    xml_uri: &str,
+) -> Option<String> {
+    let initial = context.resources().next().unwrap_or(current);
+    next_viewer_from_initial(context, initial, current.uri(), xml_uri)
+}
 
-    fn handle_viewer_js(
-        &mut self,
-        contents: &[u8],
-        xml_uri: String,
-        xml_contents: Vec<u8>,
-        mut remaining_js_uris: Vec<String>,
-    ) -> Result<DiscoveryStep, DiscoveryError> {
-        debug!("krpano: received viewer JS for {xml_uri}, attempting decryption");
-        let viewer_js = extract_viewer_js(contents).unwrap_or_else(|| contents.to_vec());
-        debug!("krpano: extracted {} bytes of viewer JS", viewer_js.len());
-        match decrypt_xml(&xml_contents, Some(&viewer_js)) {
-            Ok(decrypted) => {
-                info!("krpano: successfully decrypted XML using viewer JS");
-                self.complete(&xml_uri, &decrypted)
-            }
-            Err(error) => {
-                warn!("krpano: decryption failed with viewer JS: {error}");
-                let Some(viewer_uri) = next_js_candidate(&mut remaining_js_uris) else {
-                    return Err(DiscoveryError::Session(format!(
-                        "unable to decrypt krpano XML: {error}"
-                    )));
-                };
-                debug!("krpano: trying next viewer JS candidate {viewer_uri}");
-                self.state = SessionState::NeedViewerJs {
-                    xml_uri,
-                    xml_contents,
-                    remaining_js_uris,
-                };
-                Ok(need(&viewer_uri))
-            }
-        }
-    }
+fn next_viewer_after_failure(
+    context: &DiscoveryContext<'_>,
+    current_uri: &str,
+    xml_uri: &str,
+) -> Option<String> {
+    let initial = context.resources().next()?;
+    next_viewer_from_initial(context, initial, current_uri, xml_uri)
+}
 
-    fn complete(&mut self, uri: &str, bytes: &[u8]) -> Result<DiscoveryStep, DiscoveryError> {
-        let catalog = load_catalog(uri, bytes)?;
-        self.state = SessionState::Complete;
-        Ok(DiscoveryStep::Complete(catalog))
-    }
+fn next_viewer_from_initial(
+    context: &DiscoveryContext<'_>,
+    initial: DiscoveryResource<'_>,
+    current_uri: &str,
+    xml_uri: &str,
+) -> Option<String> {
+    let mut candidates = if looks_like_krpano_html(initial.bytes()) {
+        extract_js_candidates_from_html(&String::from_utf8_lossy(initial.bytes()), initial.uri())
+    } else if is_javascript_resource(initial) {
+        Vec::new()
+    } else {
+        viewer_js_candidates_for_xml(xml_uri)
+    };
+    candidates.retain(|candidate| candidate != current_uri && !context.has_visited(candidate));
+    next_js_candidate(&mut candidates)
+}
+
+fn is_javascript_resource(resource: DiscoveryResource<'_>) -> bool {
+    is_javascript_uri(resource.uri()) || contains_viewer_js(resource.bytes())
+}
+
+fn is_javascript_uri(uri: &str) -> bool {
+    is_javascript_src(uri)
+}
+
+fn contains_viewer_js(contents: &[u8]) -> bool {
+    extract_viewer_js(contents).is_some()
+}
+
+fn looks_like_xml_or_encrypted(contents: &[u8]) -> bool {
+    is_encrypted_xml(contents) || looks_like_krpano_xml(contents)
+}
+
+fn complete(uri: &str, bytes: &[u8]) -> Result<DiscoveryStep, DiscoveryError> {
+    load_catalog(uri, bytes).map(DiscoveryStep::Complete)
 }
 
 fn need(uri: &str) -> DiscoveryStep {
-    DiscoveryStep::Need(ResourceRequest::new(uri))
+    DiscoveryStep::follow(uri)
 }
 
 /// True if the content looks like a krpano XML file rather than HTML.
@@ -628,7 +545,8 @@ impl GridRequests for KrpanoLevel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::TileSource;
+    use crate::core::discovery::{DiscoveryOperation, ResourceFailure, ResourceNeed};
+    use crate::core::{ResourceResponse, TileSource};
 
     fn image(catalog: ImageCatalog) -> ImageDescriptor {
         match catalog.into_entries().into_iter().next().unwrap() {
@@ -653,25 +571,15 @@ mod tests {
     }
 
     fn discover_single_resource(uri: &str, bytes: Vec<u8>) -> ImageCatalog {
-        let input = DiscoveryInput::from(uri);
-        let mut session = start(&input);
-        assert!(matches!(
-            session.advance(DiscoveryEvent::Start).unwrap(),
-            DiscoveryStep::Need(ResourceRequest { request })
-                if request.uri == uri
-        ));
-        match session
-            .advance(DiscoveryEvent::Resource(&ResourceOutcome::Response(
-                crate::core::ResourceResponse {
-                    id: crate::core::RequestId(0),
-                    bytes,
-                },
-            )))
-            .unwrap()
-        {
-            DiscoveryStep::Complete(catalog) => catalog,
-            _ => panic!("plain XML completes discovery"),
-        }
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start(uri);
+        let need = operation.missing_resources().unwrap().pop().unwrap();
+        assert_eq!(need.request.uri, uri);
+        operation
+            .provide(ResourceResponse::new(need.id, bytes))
+            .unwrap();
+        operation.finish().unwrap()
     }
 
     #[test]
@@ -967,36 +875,142 @@ mod tests {
 
     #[test]
     fn viewer_js_is_detected_before_html_embed_markers() {
-        let mut session = start(&DiscoveryInput::from("https://example.com/krpano.js"));
-        let _ = session.advance(DiscoveryEvent::Start).unwrap();
-        let step = session
-            .advance(DiscoveryEvent::Resource(&ResourceOutcome::Response(
-                crate::core::ResourceResponse {
-                    id: crate::core::RequestId(0),
-                    bytes: b"function embedpano(opts) { /* krpano viewer */ }".to_vec(),
-                },
-            )))
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://example.com/krpano.js");
+        let script = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(
+                script.id,
+                b"function embedpano(opts) { /* krpano viewer */ }",
+            ))
             .unwrap();
-        assert!(
-            matches!(step, DiscoveryStep::Need(ResourceRequest { request }) if request.uri == "https://example.com/tour.xml")
+        assert_eq!(
+            operation
+                .missing_resources()
+                .unwrap()
+                .pop()
+                .unwrap()
+                .request
+                .uri,
+            "https://example.com/tour.xml"
+        );
+    }
+
+    #[test]
+    fn html_with_inline_viewer_code_keeps_its_explicit_xml_url() {
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://example.com/pano/index.html");
+        let page = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(
+                page.id,
+                br#"<html><script>
+                    function embedpano(opts) { return opts; }
+                    embedpano({xml: "scenes/custom.xml", target: "pano"});
+                </script></html>"#,
+            ))
+            .unwrap();
+        assert_eq!(
+            operation
+                .missing_resources()
+                .unwrap()
+                .pop()
+                .unwrap()
+                .request
+                .uri,
+            "https://example.com/pano/scenes/custom.xml"
         );
     }
 
     #[test]
     fn old_create_pano_viewer_js_is_detected_as_viewer_js() {
-        let mut session = start(&DiscoveryInput::from("https://example.com/viewer.js"));
-        let _ = session.advance(DiscoveryEvent::Start).unwrap();
-        let step = session
-            .advance(DiscoveryEvent::Resource(&ResourceOutcome::Response(
-                crate::core::ResourceResponse {
-                    id: crate::core::RequestId(0),
-                    bytes: b"function createPanoViewer(opts) { return buildViewer(opts); }"
-                        .to_vec(),
-                },
-            )))
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://example.com/viewer.js");
+        let script = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(
+                script.id,
+                b"function createPanoViewer(opts) { return buildViewer(opts); }",
+            ))
             .unwrap();
-        assert!(
-            matches!(step, DiscoveryStep::Need(ResourceRequest { request }) if request.uri == "https://example.com/tour.xml")
+        assert_eq!(
+            operation
+                .missing_resources()
+                .unwrap()
+                .pop()
+                .unwrap()
+                .request
+                .uri,
+            "https://example.com/tour.xml"
+        );
+    }
+
+    fn operation_waiting_for_first_viewer() -> (DiscoveryOperation, ResourceNeed) {
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://example.com/pano/index.html");
+        let page = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(
+                page.id,
+                br#"<html><script src="first.js"></script><script src="second.js"></script>
+                    <script>embedpano({xml: "tour.xml"});</script></html>"#,
+            ))
+            .unwrap();
+        let xml = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(
+                xml.id,
+                b"<encrypted>not-valid-krpano-data</encrypted>",
+            ))
+            .unwrap();
+        let viewer = operation.missing_resources().unwrap().pop().unwrap();
+        assert_eq!(viewer.request.uri, "https://example.com/pano/first.js");
+        (operation, viewer)
+    }
+
+    #[test]
+    fn failed_viewer_decryption_advances_to_the_next_candidate() {
+        let (mut operation, first) = operation_waiting_for_first_viewer();
+        operation
+            .provide(ResourceResponse::new(
+                first.id,
+                b"invalid viewer JavaScript",
+            ))
+            .unwrap();
+        assert_eq!(
+            operation
+                .missing_resources()
+                .unwrap()
+                .pop()
+                .unwrap()
+                .request
+                .uri,
+            "https://example.com/pano/second.js"
+        );
+    }
+
+    #[test]
+    fn failed_viewer_acquisition_advances_to_the_next_candidate() {
+        let (mut operation, first) = operation_waiting_for_first_viewer();
+        operation
+            .provide_failure(ResourceFailure {
+                id: first.id,
+                message: "unavailable".into(),
+            })
+            .unwrap();
+        assert_eq!(
+            operation
+                .missing_resources()
+                .unwrap()
+                .pop()
+                .unwrap()
+                .request
+                .uri,
+            "https://example.com/pano/second.js"
         );
     }
 

--- a/dezoomify-core/src/krpano/mod.rs
+++ b/dezoomify-core/src/krpano/mod.rs
@@ -12,9 +12,10 @@ use krpano_metadata::{KrpanoMetadata, XY, all_sides};
 use log::{debug, info, warn};
 
 use crate::Vec2d;
+use crate::core::discovery::ResourceFailure;
 use crate::core::resolve_relative;
 use crate::core::{
-    CatalogEntry, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryFailure, DiscoveryMatch,
+    CatalogEntry, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryMatch,
     DiscoveryResource, DiscoveryRoute, DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog,
     ImageDescriptor, LevelDescriptor, Request, StableId,
 };
@@ -24,10 +25,10 @@ use crate::template::Template;
 mod krpano_metadata;
 
 const ROUTES: &[DiscoveryRoute] = &[
-    DiscoveryMatch::content_matching(looks_like_xml_or_encrypted).then(handle_xml),
-    DiscoveryMatch::content_matching(looks_like_viewer_js).then(handle_viewer_js),
-    DiscoveryMatch::content_matching(looks_like_krpano_html).then(handle_html),
-    DiscoveryMatch::url_matching(is_javascript_uri).then(handle_viewer_js),
+    DiscoveryMatch::ContentPredicate(looks_like_xml_or_encrypted).then(handle_xml),
+    DiscoveryMatch::ContentPredicate(looks_like_viewer_js).then(handle_viewer_js),
+    DiscoveryMatch::ContentPredicate(looks_like_krpano_html).then(handle_html),
+    DiscoveryMatch::UrlPredicate(is_javascript_uri).then(handle_viewer_js),
 ];
 
 pub const SPEC: DezoomerSpec = DezoomerSpec::new("krpano", ROUTES)
@@ -47,7 +48,7 @@ fn handle_html(
         |reference| resolve_relative(resource.uri(), &reference),
     );
     debug!("krpano: resolved XML URI {xml_uri}");
-    Ok(need(&xml_uri))
+    Ok(DiscoveryStep::Follow(Request::new(xml_uri)))
 }
 
 fn handle_xml(
@@ -73,7 +74,7 @@ fn handle_xml(
                     "unable to decrypt krpano XML: {error}"
                 )))
             },
-            |uri| Ok(need(&uri)),
+            |uri| Ok(DiscoveryStep::Follow(Request::new(uri))),
         ),
     }
 }
@@ -88,7 +89,10 @@ fn handle_viewer_js(
                 "not krpano viewer JavaScript".into(),
             ));
         }
-        return Ok(need(&sibling_uri(resource.uri(), "tour.xml")));
+        return Ok(DiscoveryStep::Follow(Request::new(sibling_uri(
+            resource.uri(),
+            "tour.xml",
+        ))));
     };
     let viewer_js =
         extract_viewer_js(resource.bytes()).unwrap_or_else(|| resource.bytes().to_vec());
@@ -103,24 +107,25 @@ fn handle_viewer_js(
                     "unable to decrypt krpano XML: {error}"
                 )))
             },
-            |uri| Ok(need(&uri)),
+            |uri| Ok(DiscoveryStep::Follow(Request::new(uri))),
         ),
     }
 }
 
 fn handle_failure(
     context: &DiscoveryContext<'_>,
-    resource: DiscoveryFailure<'_>,
+    request: &Request,
+    failure: &ResourceFailure,
 ) -> Result<DiscoveryStep, DiscoveryError> {
-    let message = resource.failure().message.as_str();
+    let message = failure.message.as_str();
     debug!("krpano: resource failure: {message}");
     if let Some(xml) = find_xml(context) {
         warn!(
             "krpano: viewer JS fetch failed for {}: {message}",
             xml.uri()
         );
-        if let Some(uri) = next_viewer_after_failure(context, resource.uri(), xml.uri()) {
-            return Ok(need(&uri));
+        if let Some(uri) = next_viewer_after_failure(context, request.uri.as_str(), xml.uri()) {
+            return Ok(DiscoveryStep::Follow(Request::new(uri)));
         }
         return Err(DiscoveryError::Session(format!(
             "failed to download krpano viewer script: {message}"
@@ -170,7 +175,7 @@ fn next_viewer_from_initial(
         viewer_js_candidates_for_xml(xml_uri)
     };
     candidates.retain(|candidate| candidate != current_uri && !context.has_visited(candidate));
-    next_js_candidate(&mut candidates)
+    candidates.into_iter().next()
 }
 
 fn is_javascript_resource(resource: DiscoveryResource<'_>) -> bool {
@@ -191,10 +196,6 @@ fn looks_like_xml_or_encrypted(contents: &[u8]) -> bool {
 
 fn complete(uri: &str, bytes: &[u8]) -> Result<DiscoveryStep, DiscoveryError> {
     load_catalog(uri, bytes).map(DiscoveryStep::Complete)
-}
-
-fn need(uri: &str) -> DiscoveryStep {
-    DiscoveryStep::follow(uri)
 }
 
 /// True if the content looks like a krpano XML file rather than HTML.
@@ -409,10 +410,6 @@ fn is_common_non_viewer_script(value: &str) -> bool {
     ]
     .iter()
     .any(|needle| value.contains(needle))
-}
-
-fn next_js_candidate(candidates: &mut Vec<String>) -> Option<String> {
-    (!candidates.is_empty()).then(|| candidates.remove(0))
 }
 
 fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
@@ -973,45 +970,35 @@ mod tests {
     }
 
     #[test]
-    fn failed_viewer_decryption_advances_to_the_next_candidate() {
-        let (mut operation, first) = operation_waiting_for_first_viewer();
-        operation
-            .provide(ResourceResponse::new(
-                first.id,
-                b"invalid viewer JavaScript",
-            ))
-            .unwrap();
-        assert_eq!(
-            operation
-                .missing_resources()
-                .unwrap()
-                .pop()
-                .unwrap()
-                .request
-                .uri,
-            "https://example.com/pano/second.js"
-        );
-    }
-
-    #[test]
-    fn failed_viewer_acquisition_advances_to_the_next_candidate() {
-        let (mut operation, first) = operation_waiting_for_first_viewer();
-        operation
-            .provide_failure(ResourceFailure {
-                id: first.id,
-                message: "unavailable".into(),
-            })
-            .unwrap();
-        assert_eq!(
-            operation
-                .missing_resources()
-                .unwrap()
-                .pop()
-                .unwrap()
-                .request
-                .uri,
-            "https://example.com/pano/second.js"
-        );
+    fn failed_viewer_attempts_advance_to_the_next_candidate() {
+        for failure in [None, Some("unavailable")] {
+            let (mut operation, first) = operation_waiting_for_first_viewer();
+            if let Some(message) = failure {
+                operation
+                    .provide_failure(ResourceFailure {
+                        id: first.id,
+                        message: message.into(),
+                    })
+                    .unwrap();
+            } else {
+                operation
+                    .provide(ResourceResponse::new(
+                        first.id,
+                        b"invalid viewer JavaScript",
+                    ))
+                    .unwrap();
+            }
+            assert_eq!(
+                operation
+                    .missing_resources()
+                    .unwrap()
+                    .pop()
+                    .unwrap()
+                    .request
+                    .uri,
+                "https://example.com/pano/second.js"
+            );
+        }
     }
 
     #[test]

--- a/dezoomify-core/src/nypl/mod.rs
+++ b/dezoomify-core/src/nypl/mod.rs
@@ -20,8 +20,8 @@ const POSTFIX: &str = "/tiles/config.js";
 pub const SPEC: DezoomerSpec = DezoomerSpec::new(
     "nypl",
     &[
-        DiscoveryMatch::url_matching(is_view_url).map_url(metadata_url),
-        DiscoveryMatch::any().extract(catalog),
+        DiscoveryMatch::UrlPredicate(is_view_url).map_url(metadata_url),
+        DiscoveryMatch::Any.extract(catalog),
     ],
 )
 .recognizing(

--- a/dezoomify-core/src/nypl/mod.rs
+++ b/dezoomify-core/src/nypl/mod.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 
 use crate::Vec2d;
 use crate::core::{
-    CatalogEntry, DezoomerSpec, DiscoveryError, Grid, ImageCatalog, ImageDescriptor,
-    LevelDescriptor, Request, ResourceRequest, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryError, DiscoveryMatch, Grid, ImageCatalog,
+    ImageDescriptor, LevelDescriptor, Request, StableId,
 };
 use crate::json_utils::number_or_string;
 
@@ -17,23 +17,28 @@ const VIEW: &str = "https://digitalcollections.nypl.org/items/";
 const META: &str = "https://access.nypl.org/image.php/";
 const POSTFIX: &str = "/tiles/config.js";
 
-pub const SPEC: DezoomerSpec = DezoomerSpec::routed("nypl", metadata_request, catalog)
-    .recognizing(
-        |uri| uri.starts_with(VIEW) || uri.starts_with(META),
-        "not an NYPL image URL",
-    )
-    .preferring(|uri| uri.contains("digitalcollections.nypl.org"));
+pub const SPEC: DezoomerSpec = DezoomerSpec::new(
+    "nypl",
+    &[
+        DiscoveryMatch::url_matching(is_view_url).map_url(metadata_url),
+        DiscoveryMatch::any().extract(catalog),
+    ],
+)
+.recognizing(
+    |uri| uri.starts_with(VIEW) || uri.starts_with(META),
+    "not an NYPL image URL",
+)
+.preferring(|uri| uri.contains("digitalcollections.nypl.org"));
 
-fn metadata_request(input: &str) -> Result<ResourceRequest, DiscoveryError> {
-    let uri = if input.starts_with(VIEW) {
-        let id = image_id(input).ok_or_else(|| {
-            DiscoveryError::Session(format!("unable to extract NYPL image ID from {input:?}"))
-        })?;
-        format!("{META}{id}{POSTFIX}")
-    } else {
-        input.to_owned()
-    };
-    Ok(ResourceRequest::new(uri))
+fn is_view_url(uri: &str) -> bool {
+    uri.starts_with(VIEW)
+}
+
+fn metadata_url(input: &str) -> Result<Request, DiscoveryError> {
+    let id = image_id(input).ok_or_else(|| {
+        DiscoveryError::Session(format!("unable to extract NYPL image ID from {input:?}"))
+    })?;
+    Ok(Request::new(format!("{META}{id}{POSTFIX}")))
 }
 
 fn image_id(uri: &str) -> Option<String> {

--- a/dezoomify-core/src/zoomify/image_properties.rs
+++ b/dezoomify-core/src/zoomify/image_properties.rs
@@ -65,6 +65,7 @@ impl ImageProperties {
         let mut level_tiles = Vec::new();
         let mut tiles_before = Vec::new();
         let mut warnings = Vec::new();
+        let full_resolution_only = self.is_full_resolution_only();
         while u64::from(self.width) > u64::from(tile_size.x) * level_divisor
             || u64::from(self.height) > u64::from(tile_size.y) * level_divisor
         {
@@ -112,7 +113,7 @@ impl ImageProperties {
             }
         }
         let computed_tile_count = tiles_before.iter().sum::<u32>();
-        if computed_tile_count != self.num_tiles {
+        if computed_tile_count != self.num_tiles && !full_resolution_only {
             warnings.push(format!(
                 "Zoomify tile count mismatch: computed {computed_tile_count}, metadata declares {}",
                 self.num_tiles

--- a/dezoomify-core/src/zoomify/mod.rs
+++ b/dezoomify-core/src/zoomify/mod.rs
@@ -18,12 +18,17 @@ mod image_properties;
 pub const SPEC: DezoomerSpec = DezoomerSpec::stateful("zoomify", start).preferring(is_zoomify_url);
 
 static SHOW_IMAGE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)\bZ\s*\.\s*showImage\s*\(").expect("constant Zoomify showImage pattern")
+    Regex::new(r"(?i)(?:\bZ\s*\.\s*)?\bshowImage\s*\(").expect("constant Zoomify showImage pattern")
 });
 
 static FLASH_IMAGE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)\bzoomifyImagePath\s*=\s*([^&\s<'\"]+)"#)
+    Regex::new(r#"(?i)\bzoomifyImagePath\s*=\s*([^'"&]*)(?:['"&])"#)
         .expect("constant Zoomify FlashVars pattern")
+});
+
+static HTML_BASE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?is)<base\s+[^>]*\bhref\s*=\s*["']([^"']*)"#)
+        .expect("constant HTML base pattern")
 });
 
 static TILE_URL_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -106,7 +111,11 @@ impl Zoomify {
                         "not a Zoomify viewer page, metadata, or tile URL",
                     )));
                 };
-                let image_uri = resolve_relative(&self.input_uri, &image_path);
+                let page_base_uri = extract_html_base(&html).map_or_else(
+                    || self.input_uri.clone(),
+                    |base| resolve_relative(&self.input_uri, &base),
+                );
+                let image_uri = resolve_relative(&page_base_uri, &image_path);
                 let metadata_uri = append_path_component(&image_uri, "ImageProperties.xml");
                 self.state = SessionState::WaitingMetadata {
                     metadata_uri: metadata_uri.clone(),
@@ -133,20 +142,37 @@ fn append_path_component(uri: &str, component: &str) -> String {
 }
 
 fn extract_image_path(html: &str) -> Option<String> {
-    for marker in SHOW_IMAGE_RE.find_iter(html) {
-        if let Some(path) = second_javascript_string(&html[marker.end()..]) {
-            return Some(path);
-        }
-    }
-    FLASH_IMAGE_PATH_RE
+    let show_image = SHOW_IMAGE_RE.find_iter(html).find_map(|marker| {
+        second_javascript_string(&html[marker.end()..]).map(|path| (marker.start(), path))
+    });
+    let flash = FLASH_IMAGE_PATH_RE
+        .captures_iter(html)
+        .find_map(|captures| {
+            Some((
+                captures.get(0)?.start(),
+                captures.get(1)?.as_str().replace("&amp;", "&"),
+            ))
+        });
+    [show_image, flash]
+        .into_iter()
+        .flatten()
+        .min_by_key(|(offset, _)| *offset)
+        .map(|(_, path)| path)
+}
+
+fn extract_html_base(html: &str) -> Option<String> {
+    HTML_BASE_RE
         .captures(html)
         .and_then(|captures| captures.get(1))
-        .map(|path| path.as_str().replace("&amp;", "&"))
+        .map(|base| base.as_str().replace("&amp;", "&"))
 }
 
 fn second_javascript_string(arguments: &str) -> Option<String> {
-    let (remaining, _) = javascript_string(arguments)?;
-    let remaining = remaining.trim_start().strip_prefix(',')?;
+    let remaining = if let Some((remaining, _)) = javascript_string(arguments) {
+        remaining.trim_start().strip_prefix(',')?
+    } else {
+        arguments.split_once(',')?.1
+    };
     javascript_string(remaining).map(|(_, value)| value.replace("&amp;", "&"))
 }
 
@@ -237,6 +263,8 @@ fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryErr
                 Vec2d::default(),
                 move |tile| {
                     let cell: Vec2d = tile.coord.into();
+                    // Some producers declare only the full-resolution tile
+                    // count and consequently store every level in TileGroup0.
                     let tile_group = if full_resolution_only {
                         0
                     } else {
@@ -306,23 +334,31 @@ mod tests {
     }
 
     #[test]
-    fn viewer_pages_resolve_the_standard_show_image_path() {
+    fn viewer_pages_respect_html_base_and_first_show_image_path() {
         let mut registry = crate::core::Registry::new();
         registry.register(SPEC);
-        let mut operation = registry.start("https://example.com/catalog/item.html");
+        let mut operation = registry.start("https://fixtures.test/zoomify-base-href/product.html");
 
         let page = operation.missing_resources().unwrap().pop().unwrap();
-        assert_eq!(page.request.uri, "https://example.com/catalog/item.html");
+        assert_eq!(
+            page.request.uri,
+            "https://fixtures.test/zoomify-base-href/product.html"
+        );
         operation
             .provide(crate::core::ResourceResponse {
                 id: page.id,
-                bytes: br"<script>
-                    Z.showImage(
-                        'viewer',
-                        '/proxy/IMAGE_ID/',
-                        'zToolbarVisible=1'
-                    );
-                </script>"
+                bytes: br#"<!doctype html>
+                    <html>
+                      <head>
+                        <base href="https://fixtures.test/zoomify-base-href/assets/">
+                      </head>
+                      <body>
+                        <script>
+                          Z.showImage("viewer", "maps/sample");
+                          Z.showImage("viewer", "maps/missing");
+                        </script>
+                      </body>
+                    </html>"#
                     .to_vec(),
             })
             .unwrap();
@@ -330,7 +366,7 @@ mod tests {
         let metadata = operation.missing_resources().unwrap().pop().unwrap();
         assert_eq!(
             metadata.request.uri,
-            "https://example.com/proxy/IMAGE_ID/ImageProperties.xml"
+            "https://fixtures.test/zoomify-base-href/assets/maps/sample/ImageProperties.xml"
         );
         operation
             .provide(crate::core::ResourceResponse {
@@ -348,19 +384,42 @@ mod tests {
         };
         assert_eq!(
             plan.tiles_row_major().next().unwrap().unwrap().request.uri,
-            "https://example.com/proxy/IMAGE_ID/TileGroup0/0-0-0.jpg"
+            "https://fixtures.test/zoomify-base-href/assets/maps/sample/TileGroup0/0-0-0.jpg"
         );
     }
 
     #[test]
-    fn viewer_pages_support_flashvars_image_paths() {
-        assert_eq!(
-            extract_image_path(
-                r#"<param name="FlashVars" value="zoomifyImagePath=../images/book/&amp;zoomifySlider=0">"#
-            )
-            .as_deref(),
-            Some("../images/book/")
-        );
+    fn viewer_declarations_match_dezoomify_fixtures_and_capture() {
+        let cases = [
+            (
+                r#"<script>var zoomifyImagePath=/zoomify";</script>"#,
+                "/zoomify",
+            ),
+            (
+                r#"<script>showImage("viewer", "/zoomify");</script>"#,
+                "/zoomify",
+            ),
+            (
+                r#"<script>showImage(viewer, "/zoomify");</script>"#,
+                "/zoomify",
+            ),
+            (
+                r#"<script>Z.showImage("viewer", "https://example.com/proxy/IMAGE_ID/");</script>"#,
+                "https://example.com/proxy/IMAGE_ID/",
+            ),
+        ];
+        for (html, expected) in cases {
+            assert_eq!(extract_image_path(html).as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn first_viewer_declaration_wins_in_document_order() {
+        let html = r#"
+            <script>zoomifyImagePath=/first";</script>
+            <script>Z.showImage("viewer", "/second");</script>
+        "#;
+        assert_eq!(extract_image_path(html).as_deref(), Some("/first"));
     }
 
     #[test]
@@ -425,6 +484,51 @@ mod tests {
                 "http://x.fr/y/TileGroup0/3-5-0.jpg"
             ]
         );
+    }
+
+    #[test]
+    fn tile_group_boundary_matches_dezoomify() {
+        let image = ready_image(
+            "https://fixtures.test/zoomify/multiple-groups/ImageProperties.xml",
+            br#"<IMAGE_PROPERTIES WIDTH="4096" HEIGHT="4096" NUMTILES="341" VERSION="1.8" TILESIZE="256" />"#,
+        );
+        let TileSource::Grid(plan) = &image.levels[4].source else {
+            unreachable!()
+        };
+        let urls: Vec<_> = plan
+            .tiles_row_major()
+            .skip(170)
+            .take(2)
+            .map(Result::unwrap)
+            .map(|tile| tile.request.uri)
+            .collect();
+        assert_eq!(
+            urls,
+            [
+                "https://fixtures.test/zoomify/multiple-groups/TileGroup0/4-10-10.jpg",
+                "https://fixtures.test/zoomify/multiple-groups/TileGroup1/4-11-10.jpg",
+            ]
+        );
+    }
+
+    #[test]
+    fn full_resolution_numtiles_keeps_every_level_in_tile_group_zero() {
+        let image = ready_image(
+            "https://fixtures.test/zoomify-full-numtiles/ImageProperties.xml",
+            br#"<IMAGE_PROPERTIES WIDTH="10240" HEIGHT="1792" NUMTILES="280" VERSION="1.8" TILESIZE="256" />"#,
+        );
+        assert!(image.warnings.is_empty());
+        let TileSource::Grid(plan) = &image.levels.last().unwrap().source else {
+            unreachable!()
+        };
+        let urls: Vec<_> = plan
+            .tiles_row_major()
+            .map(Result::unwrap)
+            .map(|tile| tile.request.uri)
+            .collect();
+        assert_eq!(urls.len(), 280);
+        assert!(urls.iter().all(|url| url.contains("/TileGroup0/")));
+        assert!(urls.iter().any(|url| url.ends_with("/6-16-6.jpg")));
     }
 
     #[test]

--- a/dezoomify-core/src/zoomify/mod.rs
+++ b/dezoomify-core/src/zoomify/mod.rs
@@ -15,9 +15,9 @@ use crate::core::{
 mod image_properties;
 
 const ROUTES: &[DiscoveryRoute] = &[
-    DiscoveryMatch::url_matching(is_tile_url).map_url(tile_metadata),
-    DiscoveryMatch::url_suffix("ImageProperties.xml").extract(load_catalog),
-    DiscoveryMatch::content_matching(contains_zoomify_declaration)
+    DiscoveryMatch::UrlPredicate(is_tile_url).map_url(tile_metadata),
+    DiscoveryMatch::UrlSuffix("ImageProperties.xml").extract(load_catalog),
+    DiscoveryMatch::ContentPredicate(contains_zoomify_declaration)
         .then(extract_image_properties_url),
 ];
 
@@ -71,10 +71,10 @@ fn extract_image_properties_url(
         |base| resolve_relative(resource.uri(), &base),
     );
     let image_uri = resolve_relative(&page_base_uri, &image_path);
-    Ok(DiscoveryStep::follow(append_path_component(
+    Ok(DiscoveryStep::Follow(Request::new(append_path_component(
         &image_uri,
         "ImageProperties.xml",
-    )))
+    ))))
 }
 
 fn contains_zoomify_declaration(contents: &[u8]) -> bool {
@@ -132,6 +132,7 @@ fn extract_html_base(html: &str) -> Option<String> {
         .map(|base| base.as_str().replace("&amp;", "&"))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn tile_metadata(input: &str) -> Result<Request, DiscoveryError> {
     let uri = TILE_URL_RE.find(input).map_or_else(
         || input.to_owned(),

--- a/dezoomify-core/src/zoomify/mod.rs
+++ b/dezoomify-core/src/zoomify/mod.rs
@@ -6,24 +6,38 @@ use image_properties::ImageProperties;
 use regex::Regex;
 
 use crate::Vec2d;
-use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, Dezoomer, DezoomerSpec, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
-    DiscoveryStep, Grid, ImageCatalog, ImageDescriptor, LevelDescriptor, Request, ResourceOutcome,
-    ResourceRequest, StableId, resolve_relative,
+    CatalogEntry, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryMatch, DiscoveryRoute,
+    DiscoveryStep, Grid, ImageCatalog, ImageDescriptor, LevelDescriptor, Request, StableId,
+    resolve_relative,
 };
 
 mod image_properties;
 
-pub const SPEC: DezoomerSpec = DezoomerSpec::stateful("zoomify", start).preferring(is_zoomify_url);
+const ROUTES: &[DiscoveryRoute] = &[
+    DiscoveryMatch::url_matching(is_tile_url).map_url(tile_metadata),
+    DiscoveryMatch::url_suffix("ImageProperties.xml").extract(load_catalog),
+    DiscoveryMatch::content_matching(contains_zoomify_declaration)
+        .then(extract_image_properties_url),
+];
+
+pub const SPEC: DezoomerSpec = DezoomerSpec::new("zoomify", ROUTES).preferring(is_zoomify_url);
 
 static SHOW_IMAGE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)(?:\bZ\s*\.\s*)?\bshowImage\s*\(").expect("constant Zoomify showImage pattern")
+    Regex::new(r#"(?i)(?:\bZ\s*\.\s*)?\bshowImage\s*\([^,]*,\s*(?:"([^"]+)"|'([^']+)')"#)
+        .expect("constant Zoomify showImage pattern")
 });
 
 static FLASH_IMAGE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?i)\bzoomifyImagePath\s*=\s*([^'"&]*)(?:['"&])"#)
         .expect("constant Zoomify FlashVars pattern")
+});
+
+static TILE_SERVICE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?is)\btype["']?\s*:\s*["']zoomifytileservice["'].*?\btilesUrl["']?\s*:\s*["']([^"']+)"#,
+    )
+    .expect("constant Zoomify tile service pattern")
 });
 
 static HTML_BASE_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -44,95 +58,30 @@ fn is_zoomify_url(uri: &str) -> bool {
     uri.contains("/ImageProperties.xml") || is_tile_url(uri)
 }
 
-struct Zoomify {
-    input_uri: String,
-    state: SessionState,
+fn extract_image_properties_url(
+    _: &DiscoveryContext<'_>,
+    resource: crate::core::DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let html = String::from_utf8_lossy(resource.bytes());
+    let image_path = extract_image_path(&html).ok_or_else(|| {
+        DiscoveryError::Session("Zoomify viewer page does not declare an image path".into())
+    })?;
+    let page_base_uri = extract_html_base(&html).map_or_else(
+        || resource.uri().to_owned(),
+        |base| resolve_relative(resource.uri(), &base),
+    );
+    let image_uri = resolve_relative(&page_base_uri, &image_path);
+    Ok(DiscoveryStep::follow(append_path_component(
+        &image_uri,
+        "ImageProperties.xml",
+    )))
 }
 
-enum SessionState {
-    Initial,
-    WaitingPage,
-    WaitingMetadata { metadata_uri: String },
-    Complete,
-}
-
-fn start(input: &DiscoveryInput) -> Box<dyn Dezoomer> {
-    Box::new(Zoomify {
-        input_uri: input.uri.clone(),
-        state: SessionState::Initial,
-    })
-}
-
-impl Dezoomer for Zoomify {
-    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
-        match event {
-            DiscoveryEvent::Start if matches!(self.state, SessionState::Initial) => {
-                if is_zoomify_url(&self.input_uri) {
-                    let request = metadata_request(&self.input_uri)?;
-                    let metadata_uri = request.request.uri.clone();
-                    self.state = SessionState::WaitingMetadata { metadata_uri };
-                    Ok(DiscoveryStep::Need(request))
-                } else {
-                    self.state = SessionState::WaitingPage;
-                    Ok(DiscoveryStep::Need(ResourceRequest::new(
-                        self.input_uri.clone(),
-                    )))
-                }
-            }
-            DiscoveryEvent::Start => Err(DiscoveryError::Session(
-                "Zoomify session started twice".into(),
-            )),
-            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
-                self.state = SessionState::Complete;
-                Err(DiscoveryError::Session(format!(
-                    "failed to download Zoomify resource: {}",
-                    failure.message
-                )))
-            }
-            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => {
-                self.handle_response(&response.bytes)
-            }
-        }
-    }
-}
-
-impl Zoomify {
-    fn handle_response(&mut self, contents: &[u8]) -> Result<DiscoveryStep, DiscoveryError> {
-        let state = std::mem::replace(&mut self.state, SessionState::Complete);
-        match state {
-            SessionState::WaitingPage => {
-                if let Ok(catalog) = load_catalog(&self.input_uri, contents) {
-                    return Ok(DiscoveryStep::Complete(catalog));
-                }
-
-                let html = String::from_utf8_lossy(contents);
-                let Some(image_path) = extract_image_path(&html) else {
-                    return Ok(DiscoveryStep::Reject(DiscoveryDiagnostic::from(
-                        "not a Zoomify viewer page, metadata, or tile URL",
-                    )));
-                };
-                let page_base_uri = extract_html_base(&html).map_or_else(
-                    || self.input_uri.clone(),
-                    |base| resolve_relative(&self.input_uri, &base),
-                );
-                let image_uri = resolve_relative(&page_base_uri, &image_path);
-                let metadata_uri = append_path_component(&image_uri, "ImageProperties.xml");
-                self.state = SessionState::WaitingMetadata {
-                    metadata_uri: metadata_uri.clone(),
-                };
-                Ok(DiscoveryStep::Need(ResourceRequest::new(metadata_uri)))
-            }
-            SessionState::WaitingMetadata { metadata_uri } => Ok(DiscoveryStep::Complete(
-                load_catalog(&metadata_uri, contents)?,
-            )),
-            SessionState::Initial => Err(DiscoveryError::Session(
-                "Zoomify session received a resource before it started".into(),
-            )),
-            SessionState::Complete => Err(DiscoveryError::Session(
-                "Zoomify session has already completed".into(),
-            )),
-        }
-    }
+fn contains_zoomify_declaration(contents: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(contents);
+    SHOW_IMAGE_RE.is_match(&text)
+        || FLASH_IMAGE_PATH_RE.is_match(&text)
+        || TILE_SERVICE_RE.is_match(&text)
 }
 
 fn append_path_component(uri: &str, component: &str) -> String {
@@ -142,8 +91,15 @@ fn append_path_component(uri: &str, component: &str) -> String {
 }
 
 fn extract_image_path(html: &str) -> Option<String> {
-    let show_image = SHOW_IMAGE_RE.find_iter(html).find_map(|marker| {
-        second_javascript_string(&html[marker.end()..]).map(|path| (marker.start(), path))
+    let show_image = SHOW_IMAGE_RE.captures_iter(html).find_map(|captures| {
+        Some((
+            captures.get(0)?.start(),
+            captures
+                .get(1)
+                .or_else(|| captures.get(2))?
+                .as_str()
+                .replace("&amp;", "&"),
+        ))
     });
     let flash = FLASH_IMAGE_PATH_RE
         .captures_iter(html)
@@ -153,7 +109,16 @@ fn extract_image_path(html: &str) -> Option<String> {
                 captures.get(1)?.as_str().replace("&amp;", "&"),
             ))
         });
-    [show_image, flash]
+    let tile_service = TILE_SERVICE_RE
+        .captures_iter(html)
+        .filter_map(|captures| {
+            Some((
+                captures.get(0)?.start(),
+                captures.get(1)?.as_str().replace("&amp;", "&"),
+            ))
+        })
+        .min_by_key(|(offset, _)| *offset);
+    [show_image, flash, tile_service]
         .into_iter()
         .flatten()
         .min_by_key(|(offset, _)| *offset)
@@ -167,42 +132,7 @@ fn extract_html_base(html: &str) -> Option<String> {
         .map(|base| base.as_str().replace("&amp;", "&"))
 }
 
-fn second_javascript_string(arguments: &str) -> Option<String> {
-    let remaining = if let Some((remaining, _)) = javascript_string(arguments) {
-        remaining.trim_start().strip_prefix(',')?
-    } else {
-        arguments.split_once(',')?.1
-    };
-    javascript_string(remaining).map(|(_, value)| value.replace("&amp;", "&"))
-}
-
-fn javascript_string(input: &str) -> Option<(&str, String)> {
-    let input = input.trim_start();
-    let quote = input.chars().next()?;
-    if quote != '\'' && quote != '"' {
-        return None;
-    }
-
-    let mut value = String::new();
-    let mut escaped = false;
-    for (offset, character) in input[quote.len_utf8()..].char_indices() {
-        if escaped {
-            value.push(character);
-            escaped = false;
-        } else if character == '\\' {
-            escaped = true;
-        } else if character == quote {
-            let end = quote.len_utf8() + offset + character.len_utf8();
-            return Some((&input[end..], value));
-        } else {
-            value.push(character);
-        }
-    }
-    None
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn metadata_request(input: &str) -> Result<ResourceRequest, DiscoveryError> {
+fn tile_metadata(input: &str) -> Result<Request, DiscoveryError> {
     let uri = TILE_URL_RE.find(input).map_or_else(
         || input.to_owned(),
         |tile| {
@@ -224,7 +154,7 @@ fn metadata_request(input: &str) -> Result<ResourceRequest, DiscoveryError> {
             format!("{metadata}{suffix}")
         },
     );
-    Ok(ResourceRequest::new(uri))
+    Ok(Request::new(uri))
 }
 
 fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
@@ -301,25 +231,27 @@ fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryErr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::TileSource;
+    use crate::core::discovery::DiscoveryOperation;
+    use crate::core::{ResourceResponse, TileSource};
 
-    #[test]
-    fn tile_urls_request_sibling_metadata() {
+    const XML: &[u8] = br#"<IMAGE_PROPERTIES WIDTH="512" HEIGHT="256" NUMTILES="2" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#;
+
+    fn operation(uri: &str) -> DiscoveryOperation {
         let mut registry = crate::core::Registry::new();
         registry.register(SPEC);
-        let mut operation =
-            registry.start("https://example.com/images/book/TileGroup0/3-0-0.jpg?token=secret");
+        registry.start(uri)
+    }
+
+    fn provide_next(operation: &mut DiscoveryOperation, bytes: &[u8]) -> String {
         let need = operation.missing_resources().unwrap().pop().unwrap();
-        assert_eq!(
-            need.request.uri,
-            "https://example.com/images/book/ImageProperties.xml?token=secret"
-        );
+        let uri = need.request.uri.clone();
         operation
-            .provide(crate::core::ResourceResponse {
-                id: need.id,
-                bytes: br#"<IMAGE_PROPERTIES WIDTH="512" HEIGHT="256" NUMTILES="2" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#.to_vec(),
-            })
+            .provide(ResourceResponse::new(need.id, bytes))
             .unwrap();
+        uri
+    }
+
+    fn first_tile(operation: DiscoveryOperation) -> String {
         let catalog = operation.finish().unwrap();
         let CatalogEntry::Ready(image) = &catalog.entries()[0] else {
             panic!("Zoomify metadata must produce a ready image")
@@ -327,112 +259,94 @@ mod tests {
         let TileSource::Grid(plan) = &image.levels[0].source else {
             panic!("Zoomify levels must be grids")
         };
+        plan.tiles_row_major().next().unwrap().unwrap().request.uri
+    }
+
+    fn discover_viewer(page_uri: &str, page: &[u8]) -> (String, String) {
+        let mut operation = operation(page_uri);
+        assert_eq!(provide_next(&mut operation, page), page_uri);
+        let metadata = provide_next(&mut operation, XML);
+        (metadata, first_tile(operation))
+    }
+
+    #[test]
+    fn tile_urls_request_sibling_metadata() {
+        let mut operation =
+            operation("https://example.com/images/book/TileGroup0/3-0-0.jpg?token=secret");
         assert_eq!(
-            plan.tiles_row_major().next().unwrap().unwrap().request.uri,
+            provide_next(&mut operation, XML),
+            "https://example.com/images/book/ImageProperties.xml?token=secret"
+        );
+        assert_eq!(
+            first_tile(operation),
             "https://example.com/images/book/TileGroup0/0-0-0.jpg"
         );
     }
 
     #[test]
     fn viewer_pages_respect_html_base_and_first_show_image_path() {
-        let mut registry = crate::core::Registry::new();
-        registry.register(SPEC);
-        let mut operation = registry.start("https://fixtures.test/zoomify-base-href/product.html");
-
-        let page = operation.missing_resources().unwrap().pop().unwrap();
-        assert_eq!(
-            page.request.uri,
-            "https://fixtures.test/zoomify-base-href/product.html"
+        let (metadata, tile) = discover_viewer(
+            "https://fixtures.test/zoomify-base-href/product.html",
+            br#"<base href="https://fixtures.test/zoomify-base-href/assets/">
+                <script>
+                    Z.showImage("viewer", "maps/sample");
+                    Z.showImage("viewer", "maps/missing");
+                </script>"#,
         );
-        operation
-            .provide(crate::core::ResourceResponse {
-                id: page.id,
-                bytes: br#"<!doctype html>
-                    <html>
-                      <head>
-                        <base href="https://fixtures.test/zoomify-base-href/assets/">
-                      </head>
-                      <body>
-                        <script>
-                          Z.showImage("viewer", "maps/sample");
-                          Z.showImage("viewer", "maps/missing");
-                        </script>
-                      </body>
-                    </html>"#
-                    .to_vec(),
-            })
-            .unwrap();
-
-        let metadata = operation.missing_resources().unwrap().pop().unwrap();
         assert_eq!(
-            metadata.request.uri,
+            metadata,
             "https://fixtures.test/zoomify-base-href/assets/maps/sample/ImageProperties.xml"
         );
-        operation
-            .provide(crate::core::ResourceResponse {
-                id: metadata.id,
-                bytes: br#"<IMAGE_PROPERTIES WIDTH="512" HEIGHT="256" NUMTILES="2" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#.to_vec(),
-            })
-            .unwrap();
-
-        let catalog = operation.finish().unwrap();
-        let CatalogEntry::Ready(image) = &catalog.entries()[0] else {
-            panic!("Zoomify metadata must produce a ready image")
-        };
-        let TileSource::Grid(plan) = &image.levels[0].source else {
-            panic!("Zoomify levels must be grids")
-        };
         assert_eq!(
-            plan.tiles_row_major().next().unwrap().unwrap().request.uri,
+            tile,
             "https://fixtures.test/zoomify-base-href/assets/maps/sample/TileGroup0/0-0-0.jpg"
         );
     }
 
     #[test]
-    fn viewer_declarations_match_dezoomify_fixtures_and_capture() {
-        let cases = [
+    fn signed_proxy_remains_the_tile_base() {
+        let (metadata, tile) = discover_viewer(
+            "https://museum.example/viewer/object",
+            br#"<script>Z.showImage("viewer", "https://museum.example/proxy/OBJECT_ID/");</script>"#,
+        );
+        assert_eq!(
+            metadata,
+            "https://museum.example/proxy/OBJECT_ID/ImageProperties.xml"
+        );
+        assert_eq!(
+            tile,
+            "https://museum.example/proxy/OBJECT_ID/TileGroup0/0-0-0.jpg"
+        );
+    }
+
+    #[test]
+    fn extracts_general_zoomify_declarations() {
+        for (page, expected) in [
+            (r#"zoomifyImagePath=/zoomify";"#, "/zoomify"),
+            (r#"showImage("viewer", "/zoomify");"#, "/zoomify"),
+            (r#"showImage(viewer, "/zoomify");"#, "/zoomify"),
             (
-                r#"<script>var zoomifyImagePath=/zoomify";</script>"#,
-                "/zoomify",
-            ),
-            (
-                r#"<script>showImage("viewer", "/zoomify");</script>"#,
-                "/zoomify",
-            ),
-            (
-                r#"<script>showImage(viewer, "/zoomify");</script>"#,
-                "/zoomify",
-            ),
-            (
-                r#"<script>Z.showImage("viewer", "https://example.com/proxy/IMAGE_ID/");</script>"#,
+                r#"Z.showImage("viewer", "https://example.com/proxy/IMAGE_ID/");"#,
                 "https://example.com/proxy/IMAGE_ID/",
             ),
-        ];
-        for (html, expected) in cases {
-            assert_eq!(extract_image_path(html).as_deref(), Some(expected));
+            (
+                r#"{"type": "zoomifytileservice", "tilesUrl": "/zoomify"}"#,
+                "/zoomify",
+            ),
+        ] {
+            assert_eq!(extract_image_path(page).as_deref(), Some(expected));
         }
     }
 
     #[test]
-    fn first_viewer_declaration_wins_in_document_order() {
-        let html = r#"
-            <script>zoomifyImagePath=/first";</script>
-            <script>Z.showImage("viewer", "/second");</script>
-        "#;
-        assert_eq!(extract_image_path(html).as_deref(), Some("/first"));
-    }
-
-    #[test]
     fn unrelated_pages_are_rejected() {
-        let mut registry = crate::core::Registry::new();
-        registry.register(SPEC);
-        let mut operation = registry.start("https://example.com/page");
-        let page = operation.missing_resources().unwrap().pop().unwrap();
+        let mut operation = operation("https://example.com/page");
+        let need = operation.missing_resources().unwrap().pop().unwrap();
         let error = operation
-            .provide(crate::core::ResourceResponse {
-                id: page.id,
-                bytes: b"<html><body>ordinary page</body></html>".to_vec(),
-            })
+            .provide(ResourceResponse::new(
+                need.id,
+                b"<html><body>ordinary page</body></html>",
+            ))
             .unwrap_err();
         assert!(matches!(error, DiscoveryError::NoCandidateAccepted { .. }));
     }
@@ -475,68 +389,22 @@ mod tests {
             .collect();
         assert_eq!(
             urls,
-            vec![
+            [
                 "http://x.fr/y/TileGroup0/3-0-0.jpg",
                 "http://x.fr/y/TileGroup0/3-1-0.jpg",
                 "http://x.fr/y/TileGroup0/3-2-0.jpg",
                 "http://x.fr/y/TileGroup0/3-3-0.jpg",
                 "http://x.fr/y/TileGroup0/3-4-0.jpg",
-                "http://x.fr/y/TileGroup0/3-5-0.jpg"
+                "http://x.fr/y/TileGroup0/3-5-0.jpg",
             ]
         );
-    }
-
-    #[test]
-    fn tile_group_boundary_matches_dezoomify() {
-        let image = ready_image(
-            "https://fixtures.test/zoomify/multiple-groups/ImageProperties.xml",
-            br#"<IMAGE_PROPERTIES WIDTH="4096" HEIGHT="4096" NUMTILES="341" VERSION="1.8" TILESIZE="256" />"#,
-        );
-        let TileSource::Grid(plan) = &image.levels[4].source else {
-            unreachable!()
-        };
-        let urls: Vec<_> = plan
-            .tiles_row_major()
-            .skip(170)
-            .take(2)
-            .map(Result::unwrap)
-            .map(|tile| tile.request.uri)
-            .collect();
-        assert_eq!(
-            urls,
-            [
-                "https://fixtures.test/zoomify/multiple-groups/TileGroup0/4-10-10.jpg",
-                "https://fixtures.test/zoomify/multiple-groups/TileGroup1/4-11-10.jpg",
-            ]
-        );
-    }
-
-    #[test]
-    fn full_resolution_numtiles_keeps_every_level_in_tile_group_zero() {
-        let image = ready_image(
-            "https://fixtures.test/zoomify-full-numtiles/ImageProperties.xml",
-            br#"<IMAGE_PROPERTIES WIDTH="10240" HEIGHT="1792" NUMTILES="280" VERSION="1.8" TILESIZE="256" />"#,
-        );
-        assert!(image.warnings.is_empty());
-        let TileSource::Grid(plan) = &image.levels.last().unwrap().source else {
-            unreachable!()
-        };
-        let urls: Vec<_> = plan
-            .tiles_row_major()
-            .map(Result::unwrap)
-            .map(|tile| tile.request.uri)
-            .collect();
-        assert_eq!(urls.len(), 280);
-        assert!(urls.iter().all(|url| url.contains("/TileGroup0/")));
-        assert!(urls.iter().any(|url| url.ends_with("/6-16-6.jpg")));
     }
 
     #[test]
     fn titles_tile_groups_and_warnings_are_retained() {
-        let contents = br#"<IMAGE_PROPERTIES WIDTH="12000" HEIGHT="9788" NUMTILES="2477" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#;
         let image = ready_image(
             "http://example.com/images/manuscript123/ImageProperties.xml",
-            contents,
+            br#"<IMAGE_PROPERTIES WIDTH="12000" HEIGHT="9788" NUMTILES="2477" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#,
         );
         assert_eq!(image.title.as_deref(), Some("manuscript123"));
         let TileSource::Grid(plan) = &image.levels[5].source else {
@@ -549,18 +417,12 @@ mod tests {
             .collect();
         assert!(urls.contains("http://example.com/images/manuscript123/TileGroup1/5-0-14.jpg"));
         assert!(urls.contains("http://example.com/images/manuscript123/TileGroup2/5-0-15.jpg"));
-        let image = ready_image(
-            "https://library.example.edu/viewer/book_of_kells/ImageProperties.xml?cache=false",
-            br#"<IMAGE_PROPERTIES WIDTH="2000" HEIGHT="3000" NUMTILES="100" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#,
-        );
-        assert_eq!(image.title.as_deref(), Some("book_of_kells"));
+
         let image = ready_image(
             "http://example.com/ImageProperties.xml",
             br#"<IMAGE_PROPERTIES WIDTH="500" HEIGHT="500" NUMTILES="9" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#,
         );
         assert_eq!(image.title.as_deref(), Some("example.com"));
-        let contents = br#"<IMAGE_PROPERTIES WIDTH="500" HEIGHT="500" NUMTILES="9" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#;
-        let image = ready_image("http://example.com/ImageProperties.xml", contents);
         assert_eq!(
             image.warnings,
             ["Zoomify tile count mismatch: computed 5, metadata declares 9"]
@@ -577,11 +439,6 @@ mod tests {
             unreachable!()
         };
         assert_eq!(plan.count(), 280);
-        let first = plan.tiles_row_major().next().unwrap().unwrap();
-        assert_eq!(
-            first.request.uri,
-            "https://fixtures.test/zoomify-full-numtiles/TileGroup0/6-0-0.jpg"
-        );
         let urls: Vec<_> = plan
             .tiles_row_major()
             .map(Result::unwrap)

--- a/dezoomify-core/src/zoomify/mod.rs
+++ b/dezoomify-core/src/zoomify/mod.rs
@@ -29,7 +29,7 @@ static SHOW_IMAGE_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 static FLASH_IMAGE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)\bzoomifyImagePath\s*=\s*([^'"&]*)(?:['"&])"#)
+    Regex::new(r#"(?i)\bzoomifyImagePath\s*=\s*(?:"([^"]*)"|'([^']*)'|([^'"&\s]+))"#)
         .expect("constant Zoomify FlashVars pattern")
 });
 
@@ -67,8 +67,8 @@ fn extract_image_properties_url(
         DiscoveryError::Session("Zoomify viewer page does not declare an image path".into())
     })?;
     let page_base_uri = extract_html_base(&html).map_or_else(
-        || resource.uri().to_owned(),
-        |base| resolve_relative(resource.uri(), &base),
+        || resource.final_uri().to_owned(),
+        |base| resolve_relative(resource.final_uri(), &base),
     );
     let image_uri = resolve_relative(&page_base_uri, &image_path);
     Ok(DiscoveryStep::Follow(Request::new(append_path_component(
@@ -106,7 +106,12 @@ fn extract_image_path(html: &str) -> Option<String> {
         .find_map(|captures| {
             Some((
                 captures.get(0)?.start(),
-                captures.get(1)?.as_str().replace("&amp;", "&"),
+                captures
+                    .get(1)
+                    .or_else(|| captures.get(2))
+                    .or_else(|| captures.get(3))?
+                    .as_str()
+                    .replace("&amp;", "&"),
             ))
         });
     let tile_service = TILE_SERVICE_RE
@@ -252,6 +257,19 @@ mod tests {
         uri
     }
 
+    fn provide_next_at(
+        operation: &mut DiscoveryOperation,
+        bytes: &[u8],
+        final_uri: &str,
+    ) -> String {
+        let need = operation.missing_resources().unwrap().pop().unwrap();
+        let uri = need.request.uri.clone();
+        operation
+            .provide(ResourceResponse::new(need.id, bytes).with_final_uri(final_uri))
+            .unwrap();
+        uri
+    }
+
     fn first_tile(operation: DiscoveryOperation) -> String {
         let catalog = operation.finish().unwrap();
         let CatalogEntry::Ready(image) = &catalog.entries()[0] else {
@@ -305,6 +323,23 @@ mod tests {
     }
 
     #[test]
+    fn viewer_pages_resolve_relative_paths_against_the_redirect_target() {
+        let mut operation = operation("https://museum.example/object/12");
+        assert_eq!(
+            provide_next_at(
+                &mut operation,
+                br#"<script>Z.showImage("viewer", "tiles");</script>"#,
+                "https://cdn.example/viewer/12/index.html",
+            ),
+            "https://museum.example/object/12"
+        );
+        assert_eq!(
+            provide_next(&mut operation, XML),
+            "https://cdn.example/viewer/12/tiles/ImageProperties.xml"
+        );
+    }
+
+    #[test]
     fn signed_proxy_remains_the_tile_base() {
         let (metadata, tile) = discover_viewer(
             "https://museum.example/viewer/object",
@@ -324,6 +359,7 @@ mod tests {
     fn extracts_general_zoomify_declarations() {
         for (page, expected) in [
             (r#"zoomifyImagePath=/zoomify";"#, "/zoomify"),
+            (r#"zoomifyImagePath = "/zoomify";"#, "/zoomify"),
             (r#"showImage("viewer", "/zoomify");"#, "/zoomify"),
             (r#"showImage(viewer, "/zoomify");"#, "/zoomify"),
             (

--- a/dezoomify-core/src/zoomify/mod.rs
+++ b/dezoomify-core/src/zoomify/mod.rs
@@ -1,4 +1,4 @@
-//! Pure discovery for Zoomify `ImageProperties.xml` pyramids.
+//! Pure discovery for Zoomify viewers and `ImageProperties.xml` pyramids.
 
 use std::sync::{Arc, LazyLock};
 
@@ -6,16 +6,25 @@ use image_properties::ImageProperties;
 use regex::Regex;
 
 use crate::Vec2d;
+use crate::core::discovery::DiscoveryEvent;
 use crate::core::{
-    CatalogEntry, DezoomerSpec, DiscoveryError, Grid, ImageCatalog, ImageDescriptor,
-    LevelDescriptor, Request, ResourceRequest, StableId,
+    CatalogEntry, Dezoomer, DezoomerSpec, DiscoveryDiagnostic, DiscoveryError, DiscoveryInput,
+    DiscoveryStep, Grid, ImageCatalog, ImageDescriptor, LevelDescriptor, Request, ResourceOutcome,
+    ResourceRequest, StableId, resolve_relative,
 };
 
 mod image_properties;
 
-pub const SPEC: DezoomerSpec = DezoomerSpec::routed("zoomify", metadata_request, load_catalog)
-    .recognizing(is_zoomify_url, "not a Zoomify metadata or tile URL")
-    .preferring(is_zoomify_url);
+pub const SPEC: DezoomerSpec = DezoomerSpec::stateful("zoomify", start).preferring(is_zoomify_url);
+
+static SHOW_IMAGE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\bZ\s*\.\s*showImage\s*\(").expect("constant Zoomify showImage pattern")
+});
+
+static FLASH_IMAGE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)\bzoomifyImagePath\s*=\s*([^&\s<'\"]+)"#)
+        .expect("constant Zoomify FlashVars pattern")
+});
 
 static TILE_URL_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?:^|/)TileGroup\d+/\d+-\d+-\d+\.jpe?g(?:[?#].*)?$")
@@ -28,6 +37,142 @@ fn is_tile_url(uri: &str) -> bool {
 
 fn is_zoomify_url(uri: &str) -> bool {
     uri.contains("/ImageProperties.xml") || is_tile_url(uri)
+}
+
+struct Zoomify {
+    input_uri: String,
+    state: SessionState,
+}
+
+enum SessionState {
+    Initial,
+    WaitingPage,
+    WaitingMetadata { metadata_uri: String },
+    Complete,
+}
+
+fn start(input: &DiscoveryInput) -> Box<dyn Dezoomer> {
+    Box::new(Zoomify {
+        input_uri: input.uri.clone(),
+        state: SessionState::Initial,
+    })
+}
+
+impl Dezoomer for Zoomify {
+    fn advance(&mut self, event: DiscoveryEvent<'_>) -> Result<DiscoveryStep, DiscoveryError> {
+        match event {
+            DiscoveryEvent::Start if matches!(self.state, SessionState::Initial) => {
+                if is_zoomify_url(&self.input_uri) {
+                    let request = metadata_request(&self.input_uri)?;
+                    let metadata_uri = request.request.uri.clone();
+                    self.state = SessionState::WaitingMetadata { metadata_uri };
+                    Ok(DiscoveryStep::Need(request))
+                } else {
+                    self.state = SessionState::WaitingPage;
+                    Ok(DiscoveryStep::Need(ResourceRequest::new(
+                        self.input_uri.clone(),
+                    )))
+                }
+            }
+            DiscoveryEvent::Start => Err(DiscoveryError::Session(
+                "Zoomify session started twice".into(),
+            )),
+            DiscoveryEvent::Resource(ResourceOutcome::Failure(failure)) => {
+                self.state = SessionState::Complete;
+                Err(DiscoveryError::Session(format!(
+                    "failed to download Zoomify resource: {}",
+                    failure.message
+                )))
+            }
+            DiscoveryEvent::Resource(ResourceOutcome::Response(response)) => {
+                self.handle_response(&response.bytes)
+            }
+        }
+    }
+}
+
+impl Zoomify {
+    fn handle_response(&mut self, contents: &[u8]) -> Result<DiscoveryStep, DiscoveryError> {
+        let state = std::mem::replace(&mut self.state, SessionState::Complete);
+        match state {
+            SessionState::WaitingPage => {
+                if let Ok(catalog) = load_catalog(&self.input_uri, contents) {
+                    return Ok(DiscoveryStep::Complete(catalog));
+                }
+
+                let html = String::from_utf8_lossy(contents);
+                let Some(image_path) = extract_image_path(&html) else {
+                    return Ok(DiscoveryStep::Reject(DiscoveryDiagnostic::from(
+                        "not a Zoomify viewer page, metadata, or tile URL",
+                    )));
+                };
+                let image_uri = resolve_relative(&self.input_uri, &image_path);
+                let metadata_uri = append_path_component(&image_uri, "ImageProperties.xml");
+                self.state = SessionState::WaitingMetadata {
+                    metadata_uri: metadata_uri.clone(),
+                };
+                Ok(DiscoveryStep::Need(ResourceRequest::new(metadata_uri)))
+            }
+            SessionState::WaitingMetadata { metadata_uri } => Ok(DiscoveryStep::Complete(
+                load_catalog(&metadata_uri, contents)?,
+            )),
+            SessionState::Initial => Err(DiscoveryError::Session(
+                "Zoomify session received a resource before it started".into(),
+            )),
+            SessionState::Complete => Err(DiscoveryError::Session(
+                "Zoomify session has already completed".into(),
+            )),
+        }
+    }
+}
+
+fn append_path_component(uri: &str, component: &str) -> String {
+    let suffix_start = uri.find(['?', '#']).unwrap_or(uri.len());
+    let (path, suffix) = uri.split_at(suffix_start);
+    format!("{}/{component}{suffix}", path.trim_end_matches('/'))
+}
+
+fn extract_image_path(html: &str) -> Option<String> {
+    for marker in SHOW_IMAGE_RE.find_iter(html) {
+        if let Some(path) = second_javascript_string(&html[marker.end()..]) {
+            return Some(path);
+        }
+    }
+    FLASH_IMAGE_PATH_RE
+        .captures(html)
+        .and_then(|captures| captures.get(1))
+        .map(|path| path.as_str().replace("&amp;", "&"))
+}
+
+fn second_javascript_string(arguments: &str) -> Option<String> {
+    let (remaining, _) = javascript_string(arguments)?;
+    let remaining = remaining.trim_start().strip_prefix(',')?;
+    javascript_string(remaining).map(|(_, value)| value.replace("&amp;", "&"))
+}
+
+fn javascript_string(input: &str) -> Option<(&str, String)> {
+    let input = input.trim_start();
+    let quote = input.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+
+    let mut value = String::new();
+    let mut escaped = false;
+    for (offset, character) in input[quote.len_utf8()..].char_indices() {
+        if escaped {
+            value.push(character);
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if character == quote {
+            let end = quote.len_utf8() + offset + character.len_utf8();
+            return Some((&input[end..], value));
+        } else {
+            value.push(character);
+        }
+    }
+    None
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -60,6 +205,11 @@ fn load_catalog(url: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryErr
     let properties: ImageProperties = serde_xml_rs::from_reader(contents).map_err(|error| {
         DiscoveryError::Session(format!("unable to parse Zoomify XML: {error}"))
     })?;
+    if properties.width == 0 || properties.height == 0 || properties.tile_size == 0 {
+        return Err(DiscoveryError::Session(
+            "Zoomify XML must declare positive WIDTH, HEIGHT, and TILESIZE values".into(),
+        ));
+    }
     let base_url: Arc<str> = url
         .split("/ImageProperties.xml")
         .next()
@@ -153,6 +303,79 @@ mod tests {
             plan.tiles_row_major().next().unwrap().unwrap().request.uri,
             "https://example.com/images/book/TileGroup0/0-0-0.jpg"
         );
+    }
+
+    #[test]
+    fn viewer_pages_resolve_the_standard_show_image_path() {
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://example.com/catalog/item.html");
+
+        let page = operation.missing_resources().unwrap().pop().unwrap();
+        assert_eq!(page.request.uri, "https://example.com/catalog/item.html");
+        operation
+            .provide(crate::core::ResourceResponse {
+                id: page.id,
+                bytes: br"<script>
+                    Z.showImage(
+                        'viewer',
+                        '/proxy/IMAGE_ID/',
+                        'zToolbarVisible=1'
+                    );
+                </script>"
+                    .to_vec(),
+            })
+            .unwrap();
+
+        let metadata = operation.missing_resources().unwrap().pop().unwrap();
+        assert_eq!(
+            metadata.request.uri,
+            "https://example.com/proxy/IMAGE_ID/ImageProperties.xml"
+        );
+        operation
+            .provide(crate::core::ResourceResponse {
+                id: metadata.id,
+                bytes: br#"<IMAGE_PROPERTIES WIDTH="512" HEIGHT="256" NUMTILES="2" NUMIMAGES="1" VERSION="1.8" TILESIZE="256"/>"#.to_vec(),
+            })
+            .unwrap();
+
+        let catalog = operation.finish().unwrap();
+        let CatalogEntry::Ready(image) = &catalog.entries()[0] else {
+            panic!("Zoomify metadata must produce a ready image")
+        };
+        let TileSource::Grid(plan) = &image.levels[0].source else {
+            panic!("Zoomify levels must be grids")
+        };
+        assert_eq!(
+            plan.tiles_row_major().next().unwrap().unwrap().request.uri,
+            "https://example.com/proxy/IMAGE_ID/TileGroup0/0-0-0.jpg"
+        );
+    }
+
+    #[test]
+    fn viewer_pages_support_flashvars_image_paths() {
+        assert_eq!(
+            extract_image_path(
+                r#"<param name="FlashVars" value="zoomifyImagePath=../images/book/&amp;zoomifySlider=0">"#
+            )
+            .as_deref(),
+            Some("../images/book/")
+        );
+    }
+
+    #[test]
+    fn unrelated_pages_are_rejected() {
+        let mut registry = crate::core::Registry::new();
+        registry.register(SPEC);
+        let mut operation = registry.start("https://example.com/page");
+        let page = operation.missing_resources().unwrap().pop().unwrap();
+        let error = operation
+            .provide(crate::core::ResourceResponse {
+                id: page.id,
+                bytes: b"<html><body>ordinary page</body></html>".to_vec(),
+            })
+            .unwrap_err();
+        assert!(matches!(error, DiscoveryError::NoCandidateAccepted { .. }));
     }
 
     fn ready_image(url: &str, contents: &[u8]) -> ImageDescriptor {

--- a/dezoomify-core/tests/dezoomer_coverage.rs
+++ b/dezoomify-core/tests/dezoomer_coverage.rs
@@ -32,11 +32,7 @@ fn discover(input: &str, resources: &[Resource<'_>]) -> Result<ImageCatalog, Dis
                 need.request.uri
             )));
         };
-        operation.provide(ResourceResponse {
-            id: need.id,
-            bytes: bytes.to_vec(),
-            content_type: None,
-        })?;
+        operation.provide(ResourceResponse::new(need.id, bytes))?;
     }
 }
 

--- a/dezoomify-core/tests/dezoomer_coverage.rs
+++ b/dezoomify-core/tests/dezoomer_coverage.rs
@@ -35,6 +35,7 @@ fn discover(input: &str, resources: &[Resource<'_>]) -> Result<ImageCatalog, Dis
         operation.provide(ResourceResponse {
             id: need.id,
             bytes: bytes.to_vec(),
+            content_type: None,
         })?;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -961,7 +961,7 @@ mod tests {
         };
         let child = ImageDescriptor {
             id: "iiif-image".into(),
-            title: None,
+            title: Some("Discovered title".into()),
             format: "iiif".into(),
             levels: Vec::new(),
             warnings: vec!["image warning".into()],
@@ -974,6 +974,21 @@ mod tests {
         };
         assert_eq!(image.title.as_deref(), Some("Manifest title"));
         assert_eq!(image.warnings, ["manifest warning", "image warning"]);
+
+        let catalog = inherit_deferred_context(
+            ImageCatalog::new([CatalogEntry::Ready(ImageDescriptor {
+                title: Some("Discovered title".into()),
+                ..Default::default()
+            })]),
+            &DeferredImage {
+                title: None,
+                ..parent
+            },
+        );
+        let [CatalogEntry::Ready(image)] = catalog.entries() else {
+            panic!("resolved child must remain ready")
+        };
+        assert_eq!(image.title.as_deref(), Some("Discovered title"));
     }
 
     #[test]

--- a/src/native.rs
+++ b/src/native.rs
@@ -98,7 +98,9 @@ impl NativeDiscoveryDriver {
         need: ResourceNeed,
     ) -> Result<(), DiscoveryError> {
         match self.resolve(&need.request).await {
-            Ok(resource) => operation.provide(ResourceResponse::new(need.id, resource.bytes)),
+            Ok(resource) => operation.provide(
+                ResourceResponse::new(need.id, resource.bytes).with_final_uri(resource.final_uri),
+            ),
             Err(error) => operation.provide_failure(ResourceFailure {
                 id: need.id,
                 message: error.to_string(),

--- a/src/native.rs
+++ b/src/native.rs
@@ -98,11 +98,7 @@ impl NativeDiscoveryDriver {
         need: ResourceNeed,
     ) -> Result<(), DiscoveryError> {
         match self.resolve(&need.request).await {
-            Ok(resource) => operation.provide(ResourceResponse {
-                id: need.id,
-                bytes: resource.bytes,
-                content_type: resource.content_type,
-            }),
+            Ok(resource) => operation.provide(ResourceResponse::new(need.id, resource.bytes)),
             Err(error) => operation.provide_failure(ResourceFailure {
                 id: need.id,
                 message: error.to_string(),

--- a/src/native.rs
+++ b/src/native.rs
@@ -101,6 +101,7 @@ impl NativeDiscoveryDriver {
             Ok(resource) => operation.provide(ResourceResponse {
                 id: need.id,
                 bytes: resource.bytes,
+                content_type: resource.content_type,
             }),
             Err(error) => operation.provide_failure(ResourceFailure {
                 id: need.id,

--- a/src/network.rs
+++ b/src/network.rs
@@ -19,11 +19,10 @@ use crate::binary_display::display_bytes;
 use crate::errors::{TileDownloadError, ZoomError};
 use dezoomify_core::core::{ProcessingRecipe, Request, TileSpec};
 
-/// Bytes and portable response metadata acquired by the native application.
+/// Bytes acquired by the native application.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct FetchedResource {
     pub(crate) bytes: Vec<u8>,
-    pub(crate) content_type: Option<String>,
 }
 
 /// Fetch a described resource with request-specific headers.
@@ -53,11 +52,6 @@ pub(crate) async fn fetch_resource<'a>(
             response.headers()
         );
         let response = response.error_for_status()?;
-        let content_type = response
-            .headers()
-            .get(header::CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .map(str::to_string);
         let mut contents = Vec::new();
         let bytes = response.bytes().await?;
         contents.extend(bytes);
@@ -67,10 +61,7 @@ pub(crate) async fn fetch_resource<'a>(
             contents.len(),
             display_bytes(&contents[..contents.len().min(256)])
         );
-        Ok(FetchedResource {
-            bytes: contents,
-            content_type,
-        })
+        Ok(FetchedResource { bytes: contents })
     } else {
         debug!("Loading file: '{uri}'");
         let result = fs::read(uri).await?;
@@ -80,10 +71,7 @@ pub(crate) async fn fetch_resource<'a>(
             result.len(),
             display_bytes(&result[..result.len().min(256)])
         );
-        Ok(FetchedResource {
-            bytes: result,
-            content_type: None,
-        })
+        Ok(FetchedResource { bytes: result })
     }
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -23,6 +23,7 @@ use dezoomify_core::core::{ProcessingRecipe, Request, TileSpec};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct FetchedResource {
     pub(crate) bytes: Vec<u8>,
+    pub(crate) final_uri: String,
 }
 
 /// Fetch a described resource with request-specific headers.
@@ -51,6 +52,7 @@ pub(crate) async fn fetch_resource<'a>(
             response.status(),
             response.headers()
         );
+        let final_uri = response.url().to_string();
         let response = response.error_for_status()?;
         let mut contents = Vec::new();
         let bytes = response.bytes().await?;
@@ -61,7 +63,10 @@ pub(crate) async fn fetch_resource<'a>(
             contents.len(),
             display_bytes(&contents[..contents.len().min(256)])
         );
-        Ok(FetchedResource { bytes: contents })
+        Ok(FetchedResource {
+            bytes: contents,
+            final_uri,
+        })
     } else {
         debug!("Loading file: '{uri}'");
         let result = fs::read(uri).await?;
@@ -71,7 +76,10 @@ pub(crate) async fn fetch_resource<'a>(
             result.len(),
             display_bytes(&result[..result.len().min(256)])
         );
-        Ok(FetchedResource { bytes: result })
+        Ok(FetchedResource {
+            bytes: result,
+            final_uri: uri.to_owned(),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

This PR makes format discovery declarative and adds discovery from Zoomify viewer pages.

It addresses the Rust-side foundation of [#973](https://github.com/lovasoa/dezoomify/issues/973): format modules describe how resources are recognized and transformed, while the host application owns acquisition. The result is a single, testable discovery engine that can be driven by the native application today and leaves a clean boundary for a future WASM/browser host.

The whole PR is not a small patch: Zoomify viewer-page support and its coverage add real functionality. The discovery module itself is one line shorter than `master` while removing the former adapter/state-machine scaffolding. The new behavior is covered by deterministic tests and the local CI-equivalent commands listed below.

## New Design

A resource-consuming format declares one ordered route table. The first matching route controls the next step:

```rust
const ROUTES: &[DiscoveryRoute] = &[
    DiscoveryMatch::UrlPredicate(is_tile_url).map_url(tile_metadata),
    DiscoveryMatch::UrlSuffix("ImageProperties.xml").extract(load_catalog),
    DiscoveryMatch::ContentPredicate(contains_zoomify_declaration)
        .then(extract_image_properties_url),
];
```

The operation and its host are deliberately separate:

```mermaid
flowchart LR
    Input["Input URI"] --> Registry["Registry"]
    Registry --> Operation["DiscoveryOperation"]
    Operation -->|"Need Request"| Host["Native or future browser host"]
    Host -->|"Bytes or failure"| Operation
    Operation --> Routes["Ordered DiscoveryRoute table"]
    Routes -->|"map_url"| Request["Canonical Request"]
    Request --> Host
    Routes -->|"then / Follow"| Operation
    Routes -->|"extract / Complete"| Catalog["ImageCatalog"]
    Operation -->|"immediate"| Catalog
```

- `immediate` handles URI-only formats such as generic tile templates without a metadata request.
- `map_url` rewrites the initial URI or any later followed URI before acquisition. A mapper returns the authoritative `Request`; an unmapped follow-up retains its original request, including headers.
- `extract` passes the requested URI and bytes directly to a catalog parser.
- `then` receives the current resource plus candidate-local successful-resource history and can follow another `Request` or complete a catalog.
- The core owns ordered candidate scheduling, request IDs, request deduplication, candidate-local history, failure callbacks, cycle rejection, metadata retention, and operation limits.
- Resource acquisition, HTTP redirects, filesystem access, retries, decoding, and output encoding remain outside `dezoomify-core`.

Deduplication is shared across candidates, but history is not. This lets two candidates reuse one acquired resource without allowing one candidate's path to suppress another candidate's valid path.

## Zoomify Viewer Support

Zoomify now accepts viewer-page input in addition to direct `ImageProperties.xml` and `TileGroup` URLs. The page parser covers the general forms represented by the existing implementation and fixtures:

- qualified and unqualified `showImage(...)`
- legacy `zoomifyImagePath`
- OpenLayers `type: "zoomifytileservice"` with `tilesUrl`
- relative paths resolved against HTML `<base href>`
- direct tile URLs mapped to sibling `ImageProperties.xml`
- tile-group arithmetic and full-resolution-only `NUMTILES` layouts

The requested metadata/proxy path remains the tile base. This is important for signing proxies that redirect metadata and tile requests to separate short-lived URLs: generated tile requests continue to use the requested proxy path rather than incorrectly using the redirect-final URL.

## Compatibility And Risks

This is an intentional breaking change to the unreleased discovery API. The former `DiscoveryInput`, request-adapter, and public state-machine/`Need`/`Reject` forms are not preserved behind a compatibility layer. The public route declarations are also kept minimal by using the matcher variants directly and the explicit `DiscoveryStep::Follow(Request)` form.

Known limitations and risks are explicit:

- `dezoomify-core` is still a pure Rust library, not a WASM/browser product. Browser transport, worker orchestration, canvas assembly, and secure proxy work from #973 remain future work.
- Content predicates run after a resource is acquired. They do not avoid the initial fetch, and route order is part of format precedence.
- `map_url` replacements are authoritative and can intentionally discard headers from the input request. Mappers must add any required headers themselves; unmapped follow-ups preserve headers.
- Request deduplication uses a bounded linear vector rather than a second index. This keeps the state compact and is sufficient for the default resource limit, but lookup is O(n) for an operation with n retained resources.
- A failure callback selects the next discovery action; it is not a general retry policy. Transport retries remain a host concern.
- Zoomify page extraction is heuristic HTML/JavaScript pattern matching. It does not claim parity with every historical site-specific rewrite, iframe recursion, or arbitrary `<url>` convention in the legacy application.
- The signed-proxy behavior is validated by the supplied regression, but another proxy may require mapper-specific headers or a different canonical base and may need a future adapter.
- Full legacy parity, WASM handles, multiple-image browser selection, and browser memory/output limits are not part of this PR.

## Validation

All of the following passed locally on commit `b8b2002`:

```sh
cargo build --locked
cargo test
cargo test --workspace
cargo bench
cargo clippy --tests -- -D warnings
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
git diff --check
```

The GitHub Actions workflow completed successfully on Ubuntu, macOS, and Windows for [run 33393000312](https://github.com/lovasoa/dezoomify-rs/actions/runs/33393000312), including the locked build, tests, benchmarks, and `cargo clippy --tests -- -D warnings`.

