### PR TITLE
Discover Micrio custom elements

### DIFF
--- a/dezoomify-core/src/iiif/mod.rs
+++ b/dezoomify-core/src/iiif/mod.rs
@@ -1,12 +1,14 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use custom_error::custom_error;
+use regex::bytes::Regex as BytesRegex;
 use tile_info::ImageInfo;
 
 use crate::Vec2d;
 use crate::core::{
-    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryError, DiscoveryMatch, Grid, GridRequests,
-    GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor, Request, StableId,
+    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryMatch,
+    DiscoveryResource, DiscoveryRoute, DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog,
+    ImageDescriptor, LevelDescriptor, Request, StableId,
 };
 use crate::iiif::tile_info::TileSizeFormat;
 use crate::json_utils::all_json;
@@ -17,11 +19,20 @@ pub mod tile_info;
 #[cfg(test)]
 mod title_tests;
 
+static MICRIO_CUSTOM_ELEMENT: LazyLock<BytesRegex> = LazyLock::new(|| {
+    BytesRegex::new(r#"(?is)<micr-io\b[^>]*\bid\s*=\s*["'](?P<id>[A-Za-z0-9]{5})["']"#)
+        .expect("constant Micrio custom element pattern")
+});
+
+const ROUTES: &[DiscoveryRoute] = &[
+    DiscoveryMatch::ContentPredicate(contains_micrio_element).then(follow_micrio_element),
+    DiscoveryMatch::Any.extract(catalog),
+];
+
 /// IIIF dezoomer. See <https://iiif.io/>.
-pub const SPEC: DezoomerSpec = DezoomerSpec::new("iiif", &[DiscoveryMatch::Any.extract(catalog)])
-    .preferring(|uri| {
-        uri.contains("info.json") || uri.contains("iiif") || uri.contains("manifest.json")
-    });
+pub const SPEC: DezoomerSpec = DezoomerSpec::new("iiif", ROUTES).preferring(|uri| {
+    uri.contains("info.json") || uri.contains("iiif") || uri.contains("manifest.json")
+});
 
 /// Determines the best title for an image from IIIF manifest metadata
 #[must_use]
@@ -61,6 +72,26 @@ impl From<IIIFError> for DiscoveryError {
     fn from(err: IIIFError) -> Self {
         Self::Session(err.to_string())
     }
+}
+
+fn contains_micrio_element(contents: &[u8]) -> bool {
+    MICRIO_CUSTOM_ELEMENT.is_match(contents)
+}
+
+fn follow_micrio_element(
+    _: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let id = MICRIO_CUSTOM_ELEMENT
+        .captures(resource.bytes())
+        .and_then(|captures| captures.name("id"))
+        .map(|capture| std::str::from_utf8(capture.as_bytes()))
+        .transpose()
+        .map_err(|_| DiscoveryError::Session("Micrio custom element ID is not UTF-8".into()))?
+        .ok_or_else(|| DiscoveryError::Session("Micrio custom element lacks an ID".into()))?;
+    Ok(DiscoveryStep::Follow(Request::new(format!(
+        "https://i.micr.io/{id}/info.json"
+    ))))
 }
 
 fn catalog(uri: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryError> {

--- a/dezoomify-core/testdata/micrio/info.json
+++ b/dezoomify-core/testdata/micrio/info.json
@@ -1,0 +1,10 @@
+{
+  "@context": "http://iiif.io/api/image/3/context.json",
+  "id": "https://i.micr.io/KEimL",
+  "type": "ImageService3",
+  "width": 512,
+  "height": 512,
+  "tiles": [{ "width": 256, "height": 256, "scaleFactors": [1, 2] }],
+  "extraQualities": ["default"],
+  "extraFormats": ["jpg"]
+}

--- a/dezoomify-core/testdata/micrio/viewer.html
+++ b/dezoomify-core/testdata/micrio/viewer.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<micr-io data-view="default" id="KEimL"></micr-io>

--- a/dezoomify-core/tests/dezoomer_coverage.rs
+++ b/dezoomify-core/tests/dezoomer_coverage.rs
@@ -227,6 +227,27 @@ fn dezoomer_iiif_image_service_cases() {
             .any(|url| url == "https://fixtures.test/iiif-v3/0,0,256,256/256,256/0/default.jpg")
     );
 
+    let page_input = "https://fixtures.test/micrio/viewer.html";
+    let micrio_info_input = "https://i.micr.io/KEimL/info.json";
+    let image = ready_image(
+        discover(
+            page_input,
+            &[
+                (page_input, include_bytes!("../testdata/micrio/viewer.html")),
+                (
+                    micrio_info_input,
+                    include_bytes!("../testdata/micrio/info.json"),
+                ),
+            ],
+        )
+        .unwrap(),
+    );
+    assert!(
+        tile_urls(image.levels.last().unwrap())
+            .iter()
+            .any(|url| url == "https://i.micr.io/KEimL/256,256,256,256/256,256/0/default.jpg")
+    );
+
     let input = "https://fixtures.test/iiif-v3/non-divisible/info.json";
     let non_divisible = br#"{
       "@context": "http://iiif.io/api/image/3/context.json",


### PR DESCRIPTION
Part of lovasoa/dezoomify#973, section 2. Adds the legacy <micr-io id> IIIF adapter, which follows the canonical Micrio info.json endpoint and reuses the existing IIIF parser and tile plan. Includes deterministic discovery coverage. Validation: cargo test --workspace; cargo fmt --check; cargo clippy --workspace --all-targets -- -D warnings.