### PR TITLE
Use fixtures for coverage resources

### DIFF
--- a/dezoomify-core/testdata/coverage/iiif/default-port-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/default-port-info.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/image/2/context.json",
+  "@id": "http://127.0.0.1:80/iiif/default-port",
+  "width": 512,
+  "height": 512,
+  "tiles": [{ "width": 256, "scaleFactors": [1, 2] }],
+  "qualities": ["native"],
+  "formats": ["jpg"]
+}

--- a/dezoomify-core/testdata/coverage/iiif/edge-dimensions-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/edge-dimensions-info.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/image/2/context.json",
+  "@id": "https://fixtures.test/iiif-v2/edge-dimensions",
+  "width": 600,
+  "height": 384,
+  "tiles": [{ "width": 256, "height": 256, "scaleFactors": [1] }],
+  "qualities": ["default"],
+  "formats": ["jpg"]
+}

--- a/dezoomify-core/testdata/coverage/iiif/malformed-tile-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/malformed-tile-info.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/image/2/context.json",
+  "@id": "https://fixtures.test/iiif-malformed-tile",
+  "width": 512,
+  "height": 512,
+  "tile_width": 4096,
+  "qualities": ["default"],
+  "formats": ["jpg"]
+}

--- a/dezoomify-core/testdata/coverage/iiif/map-view-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/map-view-info.json
@@ -1,0 +1,12 @@
+{
+  "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+  "@id": "https://fixtures.test/iiif-map-view",
+  "width": 9392,
+  "height": 8770,
+  "tile_width": 9392,
+  "tile_height": 8770,
+  "scale_factors": [1, 2, 4, 8, 16, 32, 64, 128],
+  "qualities": ["native"],
+  "formats": ["jpg"],
+  "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2"
+}

--- a/dezoomify-core/testdata/coverage/iiif/non-divisible-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/non-divisible-info.json
@@ -1,0 +1,10 @@
+{
+  "@context": "http://iiif.io/api/image/3/context.json",
+  "id": "https://fixtures.test/iiif-v3/non-divisible",
+  "type": "ImageService3",
+  "width": 4960,
+  "height": 5241,
+  "tiles": [{ "width": 1024, "height": 1024, "scaleFactors": [8] }],
+  "extraQualities": ["default"],
+  "extraFormats": ["jpg"]
+}

--- a/dezoomify-core/testdata/coverage/iiif/plain-image-manifest.json
+++ b/dezoomify-core/testdata/coverage/iiif/plain-image-manifest.json
@@ -1,0 +1,10 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://fixtures.test/iiif-presentation/plain-image-manifest.json",
+  "@type": "sc:Manifest",
+  "sequences": [{ "canvases": [{ "images": [{ "resource": {
+    "@id": "https://fixtures.test/iiif-presentation/plain.jpg",
+    "@type": "dctypes:Image",
+    "format": "image/jpeg"
+  }}]}]}]
+}

--- a/dezoomify-core/testdata/coverage/iiif/presentation-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/presentation-info.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/image/2/context.json",
+  "@id": "https://fixtures.test/iiif-presentation/image",
+  "width": 512,
+  "height": 512,
+  "tiles": [{ "width": 256, "scaleFactors": [1, 2] }],
+  "qualities": ["native"],
+  "formats": ["jpg"]
+}

--- a/dezoomify-core/testdata/coverage/iiif/presentation-manifest.json
+++ b/dezoomify-core/testdata/coverage/iiif/presentation-manifest.json
@@ -1,0 +1,10 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://fixtures.test/iiif-presentation/manifest.json",
+  "@type": "sc:Manifest",
+  "sequences": [{ "canvases": [{ "images": [{ "resource": {
+    "@id": "https://fixtures.test/iiif-presentation/full.jpg",
+    "service": [{ "@id": "https://fixtures.test/iiif-presentation/image",
+      "profile": "http://iiif.io/api/image/2/level2.json" }]
+  }}]}]}]
+}

--- a/dezoomify-core/testdata/coverage/iiif/private-id-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/private-id-info.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/image/2/context.json",
+  "@id": "http://10.0.0.42/iiif/private-id",
+  "width": 512,
+  "height": 512,
+  "tiles": [{ "width": 256, "scaleFactors": [1, 2] }],
+  "qualities": ["native"],
+  "formats": ["png"]
+}

--- a/dezoomify-core/testdata/coverage/iiif/v2-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/v2-info.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/image/2/context.json",
+  "@id": "http://127.0.0.1:9877/iiif/v2",
+  "width": 512,
+  "height": 512,
+  "tiles": [{ "width": 256, "scaleFactors": [1, 2] }],
+  "qualities": ["native"],
+  "formats": ["png"]
+}

--- a/dezoomify-core/testdata/coverage/iiif/v3-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/v3-info.json
@@ -1,0 +1,10 @@
+{
+  "@context": "http://iiif.io/api/image/3/context.json",
+  "id": "https://fixtures.test/iiif-v3",
+  "type": "ImageService3",
+  "width": 512,
+  "height": 512,
+  "tiles": [{ "width": 256, "height": 256, "scaleFactors": [1, 2] }],
+  "extraQualities": ["default", "gray"],
+  "extraFormats": ["jpg", "webp"]
+}

--- a/dezoomify-core/tests/dezoomer_coverage.rs
+++ b/dezoomify-core/tests/dezoomer_coverage.rs
@@ -15,6 +15,12 @@ use dezoomify_core::core::{
 
 type Resource<'a> = (&'a str, &'a [u8]);
 
+macro_rules! coverage_fixture {
+    ($path:literal) => {
+        include_bytes!(concat!("../testdata/coverage/", $path))
+    };
+}
+
 fn discover(input: &str, resources: &[Resource<'_>]) -> Result<ImageCatalog, DiscoveryError> {
     let registry = default_registry(input);
     let mut operation = registry.start(input);
@@ -187,31 +193,11 @@ fn dezoomer_deepzoom_overlap_case() {
     );
 }
 
-const IIIF_V2: &[u8] = br#"{
-  "@context": "http://iiif.io/api/image/2/context.json",
-  "@id": "http://127.0.0.1:9877/iiif/v2",
-  "width": 512,
-  "height": 512,
-  "tiles": [{ "width": 256, "scaleFactors": [1, 2] }],
-  "qualities": ["native"],
-  "formats": ["png"]
-}"#;
-
-const IIIF_V3: &[u8] = br#"{
-  "@context": "http://iiif.io/api/image/3/context.json",
-  "id": "https://fixtures.test/iiif-v3",
-  "type": "ImageService3",
-  "width": 512,
-  "height": 512,
-  "tiles": [{ "width": 256, "height": 256, "scaleFactors": [1, 2] }],
-  "extraQualities": ["default", "gray"],
-  "extraFormats": ["jpg", "webp"]
-}"#;
-
 #[test]
 fn dezoomer_iiif_image_service_cases() {
     let input = "http://127.0.0.1:9877/fixtures/iiif-v2/info.json";
-    let image = ready_image(discover(input, &[(input, IIIF_V2)]).unwrap());
+    let image =
+        ready_image(discover(input, &[(input, coverage_fixture!("iiif/v2-info.json"))]).unwrap());
     assert_eq!(image.format.as_str(), "iiif");
     assert!(
         tile_urls(image.levels.last().unwrap())
@@ -220,7 +206,8 @@ fn dezoomer_iiif_image_service_cases() {
     );
 
     let input = "https://fixtures.test/iiif-v3/info.json";
-    let image = ready_image(discover(input, &[(input, IIIF_V3)]).unwrap());
+    let image =
+        ready_image(discover(input, &[(input, coverage_fixture!("iiif/v3-info.json"))]).unwrap());
     assert!(
         tile_urls(image.levels.last().unwrap())
             .iter()
@@ -249,15 +236,13 @@ fn dezoomer_iiif_image_service_cases() {
     );
 
     let input = "https://fixtures.test/iiif-v3/non-divisible/info.json";
-    let non_divisible = br#"{
-      "@context": "http://iiif.io/api/image/3/context.json",
-      "id": "https://fixtures.test/iiif-v3/non-divisible",
-      "type": "ImageService3",
-      "width": 4960, "height": 5241,
-      "tiles": [{ "width": 1024, "height": 1024, "scaleFactors": [8] }],
-      "extraQualities": ["default"], "extraFormats": ["jpg"]
-    }"#;
-    let image = ready_image(discover(input, &[(input, non_divisible)]).unwrap());
+    let image = ready_image(
+        discover(
+            input,
+            &[(input, coverage_fixture!("iiif/non-divisible-info.json"))],
+        )
+        .unwrap(),
+    );
     let level = image
         .levels
         .iter()
@@ -270,16 +255,13 @@ fn dezoomer_iiif_image_service_cases() {
     );
 
     let input = "https://fixtures.test/iiif-map-view/info.json";
-    let invalid_tile_width = br#"{
-      "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
-      "@id": "https://fixtures.test/iiif-map-view",
-      "width": 9392, "height": 8770,
-      "tile_width": 9392, "tile_height": 8770,
-      "scale_factors": [1, 2, 4, 8, 16, 32, 64, 128],
-      "qualities": ["native"], "formats": ["jpg"],
-      "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2"
-    }"#;
-    let image = ready_image(discover(input, &[(input, invalid_tile_width)]).unwrap());
+    let image = ready_image(
+        discover(
+            input,
+            &[(input, coverage_fixture!("iiif/map-view-info.json"))],
+        )
+        .unwrap(),
+    );
     let level = image
         .levels
         .iter()
@@ -292,52 +274,49 @@ fn dezoomer_iiif_image_service_cases() {
     );
 
     let input = "http://127.0.0.1:9877/fixtures/iiif-private-id/info.json";
-    let private_id = br#"{
-      "@context": "http://iiif.io/api/image/2/context.json",
-      "@id": "http://10.0.0.42/iiif/private-id",
-      "width": 512, "height": 512,
-      "tiles": [{ "width": 256, "scaleFactors": [1, 2] }],
-      "qualities": ["native"], "formats": ["png"]
-    }"#;
-    let image = ready_image(discover(input, &[(input, private_id)]).unwrap());
+    let image = ready_image(
+        discover(
+            input,
+            &[(input, coverage_fixture!("iiif/private-id-info.json"))],
+        )
+        .unwrap(),
+    );
     assert!(tile_urls(image.levels.last().unwrap()).iter().any(|url| url
         == "http://127.0.0.1:9877/fixtures/iiif-private-id/0,0,256,256/256,256/0/native.png"));
 
     let input = "http://127.0.0.1:9877/fixtures/iiif-default-port/info.json";
-    let default_port = br#"{
-      "@context": "http://iiif.io/api/image/2/context.json",
-      "@id": "http://127.0.0.1:80/iiif/default-port",
-      "width": 512, "height": 512,
-      "tiles": [{ "width": 256, "scaleFactors": [1, 2] }],
-      "qualities": ["native"], "formats": ["jpg"]
-    }"#;
-    let image = ready_image(discover(input, &[(input, default_port)]).unwrap());
+    let image = ready_image(
+        discover(
+            input,
+            &[(input, coverage_fixture!("iiif/default-port-info.json"))],
+        )
+        .unwrap(),
+    );
     assert!(tile_urls(image.levels.last().unwrap()).iter().any(
         |url| url == "http://127.0.0.1:9877/iiif/default-port/0,0,256,256/256,256/0/native.jpg"
     ));
 
     let input = "https://fixtures.test/iiif-malformed-tile/info.json";
-    let malformed = br#"{
-      "@context": "http://iiif.io/api/image/2/context.json",
-      "@id": "https://fixtures.test/iiif-malformed-tile",
-      "width": 512, "height": 512, "tile_width": 4096,
-      "qualities": ["default"], "formats": ["jpg"]
-    }"#;
-    let image = ready_image(discover(input, &[(input, malformed)]).unwrap());
+    let image = ready_image(
+        discover(
+            input,
+            &[(input, coverage_fixture!("iiif/malformed-tile-info.json"))],
+        )
+        .unwrap(),
+    );
     assert_eq!(
         tile_urls(image.levels.last().unwrap()),
         ["https://fixtures.test/iiif-malformed-tile/0,0,512,512/512,512/0/default.jpg"]
     );
 
     let input = "https://fixtures.test/iiif-v2/edge-dimensions/info.json";
-    let edge_dimensions = br#"{
-      "@context": "http://iiif.io/api/image/2/context.json",
-      "@id": "https://fixtures.test/iiif-v2/edge-dimensions",
-      "width": 600, "height": 384,
-      "tiles": [{ "width": 256, "height": 256, "scaleFactors": [1] }],
-      "qualities": ["default"], "formats": ["jpg"]
-    }"#;
-    let image = ready_image(discover(input, &[(input, edge_dimensions)]).unwrap());
+    let image = ready_image(
+        discover(
+            input,
+            &[(input, coverage_fixture!("iiif/edge-dimensions-info.json"))],
+        )
+        .unwrap(),
+    );
     assert!(tile_urls(image.levels.last().unwrap()).iter().any(|url| url
         == "https://fixtures.test/iiif-v2/edge-dimensions/256,256,256,128/256,128/0/default.jpg"));
 }
@@ -345,27 +324,16 @@ fn dezoomer_iiif_image_service_cases() {
 #[test]
 fn dezoomer_iiif_manifest_case() {
     let manifest_input = "https://fixtures.test/iiif-presentation/manifest.json";
-    let manifest = br#"{
-      "@context": "http://iiif.io/api/presentation/2/context.json",
-      "@id": "https://fixtures.test/iiif-presentation/manifest.json",
-      "@type": "sc:Manifest",
-      "sequences": [{"canvases": [{"images": [{"resource": {
-        "@id": "https://fixtures.test/iiif-presentation/full.jpg",
-        "service": [{"@id": "https://fixtures.test/iiif-presentation/image",
-          "profile": "http://iiif.io/api/image/2/level2.json"}]
-      }}]}]}]
-    }"#;
     let info_input = "https://fixtures.test/iiif-presentation/image/info.json";
-    let info = br#"{
-      "@context": "http://iiif.io/api/image/2/context.json",
-      "@id": "https://fixtures.test/iiif-presentation/image",
-      "width": 512, "height": 512,
-      "tiles": [{ "width": 256, "scaleFactors": [1, 2] }],
-      "qualities": ["native"], "formats": ["jpg"]
-    }"#;
     let catalog = discover(
         manifest_input,
-        &[(manifest_input, manifest), (info_input, info)],
+        &[
+            (
+                manifest_input,
+                coverage_fixture!("iiif/presentation-manifest.json"),
+            ),
+            (info_input, coverage_fixture!("iiif/presentation-info.json")),
+        ],
     )
     .unwrap();
     let [CatalogEntry::Deferred(deferred)] = catalog.entries() else {
@@ -373,7 +341,13 @@ fn dezoomer_iiif_manifest_case() {
     };
     assert_eq!(deferred.uri, info_input);
 
-    let image = ready_image(discover(info_input, &[(info_input, info)]).unwrap());
+    let image = ready_image(
+        discover(
+            info_input,
+            &[(info_input, coverage_fixture!("iiif/presentation-info.json"))],
+        )
+        .unwrap(),
+    );
     assert!(
         tile_urls(image.levels.last().unwrap())
             .iter()
@@ -384,16 +358,11 @@ fn dezoomer_iiif_manifest_case() {
 #[test]
 fn dezoomer_iiif_plain_image_manifest_remains_deferred() {
     let input = "https://fixtures.test/iiif-presentation/plain-image-manifest.json";
-    let manifest = br#"{
-      "@context": "http://iiif.io/api/presentation/2/context.json",
-      "@id": "https://fixtures.test/iiif-presentation/plain-image-manifest.json",
-      "@type": "sc:Manifest",
-      "sequences": [{"canvases": [{"images": [{"resource": {
-        "@id": "https://fixtures.test/iiif-presentation/plain.jpg",
-        "@type": "dctypes:Image", "format": "image/jpeg"
-      }}]}]}]
-    }"#;
-    let catalog = discover(input, &[(input, manifest)]).unwrap();
+    let catalog = discover(
+        input,
+        &[(input, coverage_fixture!("iiif/plain-image-manifest.json"))],
+    )
+    .unwrap();
     assert!(matches!(
         &catalog.entries()[0],
         CatalogEntry::Deferred(image) if image.uri == "https://fixtures.test/iiif-presentation/plain.jpg"

--- a/tests/local_dezoomifying.rs
+++ b/tests/local_dezoomifying.rs
@@ -12,72 +12,40 @@ use tempfile::Builder as TempDirBuilder;
 
 use dezoomify_rs::{Arguments, ZoomError, dezoomify, process_bulk};
 
-/// Dezoom a file locally
-#[tokio::test(flavor = "multi_thread")]
-pub async fn custom_size_local_zoomify_tiles() {
-    // Get absolute path to avoid working directory issues
-    let workspace_root = get_workspace_root();
-    let input_path = workspace_root.join("testdata/zoomify/test_custom_size/ImageProperties.xml");
-    let expected_path =
-        workspace_root.join("testdata/zoomify/test_custom_size/expected_result.jpg");
-
-    test_image(
-        input_path.to_str().unwrap(),
-        expected_path.to_str().unwrap(),
-    )
-    .await
-    .unwrap()
+macro_rules! local_image_fixture {
+    ($name:ident, $input:literal, $expected:literal) => {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn $name() {
+            let workspace_root = get_workspace_root();
+            let input = workspace_root.join("testdata").join($input);
+            let expected = workspace_root.join("testdata").join($expected);
+            test_image(input.to_str().unwrap(), expected.to_str().unwrap())
+                .await
+                .unwrap();
+        }
+    };
 }
 
-#[tokio::test(flavor = "multi_thread")]
-pub async fn zoomify_tile_url_input() {
-    let workspace_root = get_workspace_root();
-    let input_path = workspace_root.join("testdata/zoomify/test_custom_size/TileGroup0/3-0-0.jpg");
-    let expected_source =
-        workspace_root.join("testdata/zoomify/test_custom_size/expected_result.jpg");
-    let expected_dir = TempDirBuilder::new()
-        .prefix("dezoomify-rs-zoomify-tile-test")
-        .tempdir()
-        .unwrap();
-    let expected_path = expected_dir.path().join("expected.jpg");
-    std::fs::copy(expected_source, &expected_path).unwrap();
-
-    test_image(
-        input_path.to_str().unwrap(),
-        expected_path.to_str().unwrap(),
-    )
-    .await
-    .unwrap()
-}
-
-#[tokio::test(flavor = "multi_thread")]
-pub async fn local_generic_tiles() {
-    // Get absolute path to avoid working directory issues
-    let workspace_root = get_workspace_root();
-    let input_path = workspace_root.join("testdata/generic/map_{{X}}_{{Y}}.jpg");
-    let expected_path = workspace_root.join("testdata/deepzoom/expected_result.png");
-
-    test_image(
-        input_path.to_str().unwrap(),
-        expected_path.to_str().unwrap(),
-    )
-    .await
-    .unwrap()
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn legacy_seadragon_embed() {
-    let workspace_root = get_workspace_root();
-    let input_path = workspace_root.join("testdata/deepzoom/legacy-embed.html");
-    let expected_path = workspace_root.join("testdata/generic/map_expected.png");
-
-    test_image(
-        input_path.to_str().unwrap(),
-        expected_path.to_str().unwrap(),
-    )
-    .await
-    .unwrap()
-}
+local_image_fixture!(
+    custom_size_local_zoomify_tiles,
+    "zoomify/test_custom_size/ImageProperties.xml",
+    "zoomify/test_custom_size/expected_result.jpg"
+);
+local_image_fixture!(
+    zoomify_tile_url_input,
+    "zoomify/test_custom_size/TileGroup0/3-0-0.jpg",
+    "zoomify/test_custom_size/expected_result.jpg"
+);
+local_image_fixture!(
+    local_generic_tiles,
+    "generic/map_{{X}}_{{Y}}.jpg",
+    "generic/map_expected.png"
+);
+local_image_fixture!(
+    legacy_seadragon_embed,
+    "deepzoom/legacy-embed.html",
+    "deepzoom/expected_result.png"
+);
 
 #[tokio::test(flavor = "multi_thread")]
 pub async fn bulk_mode_local_tiles() {
@@ -89,52 +57,19 @@ pub async fn bulk_mode_end_to_end_cli() {
     test_bulk_mode_cli_end_to_end().await.unwrap()
 }
 
-/// Get the workspace root directory (where Cargo.toml is located)
 fn get_workspace_root() -> PathBuf {
-    let mut current_dir = std::env::current_dir().expect("Failed to get current directory");
-
-    // Walk up the directory tree until we find Cargo.toml
-    loop {
-        if current_dir.join("Cargo.toml").exists() {
-            return current_dir;
-        }
-        if let Some(parent) = current_dir.parent() {
-            current_dir = parent.to_path_buf();
-        } else {
-            break;
-        }
-    }
-
-    // If we can't find Cargo.toml by walking up, try using the CARGO_MANIFEST_DIR environment variable
-    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
-        let manifest_path = PathBuf::from(manifest_dir);
-        if manifest_path.join("Cargo.toml").exists() {
-            return manifest_path;
-        }
-    }
-
-    // Last resort: try relative path from where tests typically run
-    let test_workspace = PathBuf::from("../");
-    if test_workspace.join("Cargo.toml").exists() {
-        return test_workspace
-            .canonicalize()
-            .expect("Failed to canonicalize path");
-    }
-
-    // If all else fails, return current directory and let tests fail with better error message
-    std::env::current_dir().expect("Failed to get current directory")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-#[allow(clippy::needless_lifetimes)]
 #[allow(clippy::field_reassign_with_default)]
-pub async fn dezoom_image<'a>(input: &str, expected: &'a str) -> Result<TmpFile<'a>, ZoomError> {
+pub async fn dezoom_image<'a>(input: &'a str, expected: &'a str) -> Result<TmpFile<'a>, ZoomError> {
     let mut args: Arguments = Default::default();
     args.input_uri = Some(input.into());
     args.largest = true;
     args.retries = 0;
     args.logging = "error".into();
 
-    let tmp_file = TmpFile(expected);
+    let tmp_file = TmpFile { input, expected };
     args.outfile = Some(tmp_file.to_path_buf());
     dezoomify(&args).await.expect("Dezooming failed");
     Ok(tmp_file)
@@ -172,13 +107,19 @@ fn assert_images_equal(a: DynamicImage, b: DynamicImage) {
     assert!(dist < 3, "The distance between the two images is {}", dist);
 }
 
-pub struct TmpFile<'a>(&'a str);
+pub struct TmpFile<'a> {
+    input: &'a str,
+    expected: &'a str,
+}
 
 impl<'a> TmpFile<'a> {
-    fn to_path_buf(&'a self) -> PathBuf {
+    fn to_path_buf(&self) -> PathBuf {
         let mut out_file = std::env::temp_dir();
-        out_file.push(format!("dezoomify-out-{}", hash(self.0)));
-        let orig_path: &Path = self.0.as_ref();
+        out_file.push(format!(
+            "dezoomify-out-{}",
+            hash((self.input, self.expected))
+        ));
+        let orig_path: &Path = self.expected.as_ref();
         out_file.set_extension(orig_path.extension().expect("missing extension"));
         out_file
     }


### PR DESCRIPTION
Moves document-sized IIIF coverage inputs to checked-in fixtures and makes local full-image cases one-line declarations.\n\nAlso gives every local download a unique output path and corrects the generic/DZI expected-fixture pairing.\n\nValidation: cargo test --workspace; cargo fmt; cargo clippy --workspace --all-targets -- -D warnings.