### PR TITLE
Discover legacy IIIF URL adapters

### DIFF
--- a/dezoomify-core/src/iiif/contentdm.rs
+++ b/dezoomify-core/src/iiif/contentdm.rs
@@ -1,0 +1,63 @@
+use url::Url;
+
+use crate::core::{DiscoveryContext, DiscoveryError, DiscoveryResource, DiscoveryStep, Request};
+
+pub(super) fn is_record(uri: &str) -> bool {
+    let Ok(url) = Url::parse(uri) else {
+        return false;
+    };
+    matches!(url.path_segments().map(Iterator::collect::<Vec<_>>).as_deref(), Some(["digital", "collection", _, "id", id, ..]) if id.parse::<u64>().is_ok())
+}
+
+pub(super) fn metadata(uri: &str) -> Result<Request, DiscoveryError> {
+    let url =
+        Url::parse(uri).map_err(|_| DiscoveryError::Session("invalid CONTENTdm URL".into()))?;
+    let segments = url
+        .path_segments()
+        .map(Iterator::collect::<Vec<_>>)
+        .ok_or_else(|| DiscoveryError::Session("invalid CONTENTdm path".into()))?;
+    let ["digital", "collection", collection, "id", identifier, ..] = segments.as_slice() else {
+        return Err(DiscoveryError::Session(
+            "invalid CONTENTdm record URL".into(),
+        ));
+    };
+    Ok(Request::new(format!(
+        "{}/digital/api/singleitem/collection/{collection}/id/{identifier}",
+        url.origin().ascii_serialization()
+    )))
+}
+
+pub(super) fn is_metadata(uri: &str) -> bool {
+    Url::parse(uri).is_ok_and(|url| {
+        matches!(
+            url.path_segments()
+                .map(Iterator::collect::<Vec<_>>)
+                .as_deref(),
+            Some(["digital", "api", "singleitem", "collection", _, "id", _])
+        )
+    })
+}
+
+pub(super) fn follow_info(
+    _: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let info_uri = serde_json::from_slice::<serde_json::Value>(resource.bytes())
+        .ok()
+        .and_then(|value| value.get("iiifInfoUri")?.as_str().map(str::to_owned))
+        .filter(|uri| !uri.is_empty())
+        .ok_or_else(|| DiscoveryError::Session("CONTENTdm metadata has no IIIF URL".into()))?;
+    let base = Url::parse(resource.final_uri())
+        .map_err(|_| DiscoveryError::Session("invalid CONTENTdm metadata URL".into()))?;
+    let origin = base.origin().ascii_serialization();
+    let uri = if Url::parse(&info_uri).is_ok() {
+        info_uri
+    } else if info_uri.starts_with("/digital/") {
+        format!("{origin}{info_uri}")
+    } else if info_uri.starts_with('/') {
+        format!("{origin}/digital{info_uri}")
+    } else {
+        format!("{origin}/digital/{info_uri}")
+    };
+    Ok(DiscoveryStep::Follow(Request::new(uri)))
+}

--- a/dezoomify-core/src/iiif/contentdm.rs
+++ b/dezoomify-core/src/iiif/contentdm.rs
@@ -1,6 +1,18 @@
 use url::Url;
 
-use crate::core::{DiscoveryContext, DiscoveryError, DiscoveryResource, DiscoveryStep, Request};
+use crate::core::{
+    DiscoveryContext, DiscoveryError, DiscoveryMatch, DiscoveryResource, DiscoveryRoute,
+    DiscoveryStep, Request,
+};
+
+pub(super) const RECORD_ROUTE: DiscoveryRoute =
+    DiscoveryMatch::UrlPredicate(is_record).map_url(metadata);
+pub(super) const METADATA_ROUTE: DiscoveryRoute =
+    DiscoveryMatch::UrlPredicate(is_metadata).then(follow_info);
+
+pub(super) fn prefers(uri: &str) -> bool {
+    is_record(uri)
+}
 
 pub(super) fn is_record(uri: &str) -> bool {
     let Ok(url) = Url::parse(uri) else {

--- a/dezoomify-core/src/iiif/micrio.rs
+++ b/dezoomify-core/src/iiif/micrio.rs
@@ -2,7 +2,13 @@ use std::sync::LazyLock;
 
 use regex::bytes::Regex as BytesRegex;
 
-use crate::core::{DiscoveryContext, DiscoveryError, DiscoveryResource, DiscoveryStep, Request};
+use crate::core::{
+    DiscoveryContext, DiscoveryError, DiscoveryMatch, DiscoveryResource, DiscoveryRoute,
+    DiscoveryStep, Request,
+};
+
+pub(super) const ROUTE: DiscoveryRoute =
+    DiscoveryMatch::ContentPredicate(contains_element).then(follow_element);
 
 static ELEMENT: LazyLock<BytesRegex> = LazyLock::new(|| {
     BytesRegex::new(r#"(?is)<micr-io\b[^>]*\bid\s*=\s*["'](?P<id>[A-Za-z0-9]{5})["']"#)

--- a/dezoomify-core/src/iiif/micrio.rs
+++ b/dezoomify-core/src/iiif/micrio.rs
@@ -1,0 +1,30 @@
+use std::sync::LazyLock;
+
+use regex::bytes::Regex as BytesRegex;
+
+use crate::core::{DiscoveryContext, DiscoveryError, DiscoveryResource, DiscoveryStep, Request};
+
+static ELEMENT: LazyLock<BytesRegex> = LazyLock::new(|| {
+    BytesRegex::new(r#"(?is)<micr-io\b[^>]*\bid\s*=\s*["'](?P<id>[A-Za-z0-9]{5})["']"#)
+        .expect("constant Micrio custom element pattern")
+});
+
+pub(super) fn contains_element(contents: &[u8]) -> bool {
+    ELEMENT.is_match(contents)
+}
+
+pub(super) fn follow_element(
+    _: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let id = ELEMENT
+        .captures(resource.bytes())
+        .and_then(|captures| captures.name("id"))
+        .map(|capture| std::str::from_utf8(capture.as_bytes()))
+        .transpose()
+        .map_err(|_| DiscoveryError::Session("Micrio custom element ID is not UTF-8".into()))?
+        .ok_or_else(|| DiscoveryError::Session("Micrio custom element lacks an ID".into()))?;
+    Ok(DiscoveryStep::Follow(Request::new(format!(
+        "https://i.micr.io/{id}/info.json"
+    ))))
+}

--- a/dezoomify-core/src/iiif/mod.rs
+++ b/dezoomify-core/src/iiif/mod.rs
@@ -1,36 +1,33 @@
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use custom_error::custom_error;
-use regex::bytes::Regex as BytesRegex;
 use tile_info::ImageInfo;
 use url::Url;
 
 use crate::Vec2d;
 use crate::core::{
-    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryMatch,
-    DiscoveryResource, DiscoveryRoute, DiscoveryStep, Grid, GridRequests, GridTile, ImageCatalog,
-    ImageDescriptor, LevelDescriptor, Request, StableId,
+    CatalogEntry, DeferredImage, DezoomerSpec, DiscoveryError, DiscoveryMatch, DiscoveryRoute,
+    Grid, GridRequests, GridTile, ImageCatalog, ImageDescriptor, LevelDescriptor, Request,
+    StableId,
 };
 use crate::iiif::tile_info::TileSizeFormat;
 use crate::json_utils::all_json;
 
+mod contentdm;
 pub mod manifest_types;
+mod micrio;
+mod onb;
 pub mod tile_info;
 
 #[cfg(test)]
 mod title_tests;
 
-static MICRIO_CUSTOM_ELEMENT: LazyLock<BytesRegex> = LazyLock::new(|| {
-    BytesRegex::new(r#"(?is)<micr-io\b[^>]*\bid\s*=\s*["'](?P<id>[A-Za-z0-9]{5})["']"#)
-        .expect("constant Micrio custom element pattern")
-});
-
 const ROUTES: &[DiscoveryRoute] = &[
     DiscoveryMatch::UrlPredicate(has_manifest_parameter).map_url(manifest_parameter),
-    DiscoveryMatch::UrlPredicate(is_onb_entry).map_url(onb_manifest),
-    DiscoveryMatch::UrlPredicate(is_contentdm_record).map_url(contentdm_metadata),
-    DiscoveryMatch::UrlPredicate(is_contentdm_metadata).then(follow_contentdm_info),
-    DiscoveryMatch::ContentPredicate(contains_micrio_element).then(follow_micrio_element),
+    DiscoveryMatch::UrlPredicate(onb::is_entry).map_url(onb::manifest),
+    DiscoveryMatch::UrlPredicate(contentdm::is_record).map_url(contentdm::metadata),
+    DiscoveryMatch::UrlPredicate(contentdm::is_metadata).then(contentdm::follow_info),
+    DiscoveryMatch::ContentPredicate(micrio::contains_element).then(micrio::follow_element),
     DiscoveryMatch::Any.extract(catalog),
 ];
 
@@ -40,8 +37,8 @@ pub const SPEC: DezoomerSpec = DezoomerSpec::new("iiif", ROUTES).preferring(|uri
         || uri.contains("iiif")
         || uri.contains("manifest.json")
         || has_manifest_parameter(uri)
-        || is_onb_entry(uri)
-        || is_contentdm_record(uri)
+        || onb::is_entry(uri)
+        || contentdm::is_record(uri)
 });
 
 /// Determines the best title for an image from IIIF manifest metadata
@@ -105,116 +102,6 @@ fn manifest_parameter_value(uri: &str) -> Option<String> {
             })
         })
         .filter(|value| !value.is_empty())
-}
-
-fn is_onb_entry(uri: &str) -> bool {
-    let Ok(url) = Url::parse(uri) else {
-        return false;
-    };
-    matches!(url.host_str(), Some("viewer.onb.ac.at"))
-        || matches!(url.host_str(), Some("digital.onb.ac.at"))
-            && url.path() == "/RepViewer/viewer.faces"
-            && url.query_pairs().any(|(name, _)| name == "doc")
-}
-
-fn onb_manifest(uri: &str) -> Result<Request, DiscoveryError> {
-    let url = Url::parse(uri).map_err(|_| DiscoveryError::Session("invalid ONB URL".into()))?;
-    let identifier = match url.host_str() {
-        Some("viewer.onb.ac.at") => url
-            .path_segments()
-            .and_then(|mut segments| segments.next())
-            .map(str::to_owned),
-        Some("digital.onb.ac.at") => url
-            .query_pairs()
-            .find_map(|(name, value)| (name == "doc").then(|| value.into_owned())),
-        _ => None,
-    }
-    .filter(|identifier| !identifier.is_empty())
-    .ok_or_else(|| DiscoveryError::Session("missing ONB document identifier".into()))?;
-    Ok(Request::new(format!(
-        "https://api.onb.ac.at/iiif/presentation/v3/manifest/{identifier}"
-    )))
-}
-
-fn is_contentdm_record(uri: &str) -> bool {
-    let Ok(url) = Url::parse(uri) else {
-        return false;
-    };
-    let segments = url.path_segments().map(Iterator::collect::<Vec<_>>);
-    matches!(segments.as_deref(), Some(["digital", "collection", _, "id", id, ..]) if id.parse::<u64>().is_ok())
-}
-
-fn contentdm_metadata(uri: &str) -> Result<Request, DiscoveryError> {
-    let url =
-        Url::parse(uri).map_err(|_| DiscoveryError::Session("invalid CONTENTdm URL".into()))?;
-    let segments = url
-        .path_segments()
-        .map(Iterator::collect::<Vec<_>>)
-        .ok_or_else(|| DiscoveryError::Session("invalid CONTENTdm path".into()))?;
-    let ["digital", "collection", collection, "id", identifier, ..] = segments.as_slice() else {
-        return Err(DiscoveryError::Session(
-            "invalid CONTENTdm record URL".into(),
-        ));
-    };
-    Ok(Request::new(format!(
-        "{}/digital/api/singleitem/collection/{collection}/id/{identifier}",
-        url.origin().ascii_serialization()
-    )))
-}
-
-fn is_contentdm_metadata(uri: &str) -> bool {
-    Url::parse(uri).is_ok_and(|url| {
-        matches!(
-            url.path_segments()
-                .map(Iterator::collect::<Vec<_>>)
-                .as_deref(),
-            Some(["digital", "api", "singleitem", "collection", _, "id", _])
-        )
-    })
-}
-
-fn follow_contentdm_info(
-    _: &DiscoveryContext<'_>,
-    resource: DiscoveryResource<'_>,
-) -> Result<DiscoveryStep, DiscoveryError> {
-    let info_uri = serde_json::from_slice::<serde_json::Value>(resource.bytes())
-        .ok()
-        .and_then(|value| value.get("iiifInfoUri")?.as_str().map(str::to_owned))
-        .filter(|uri| !uri.is_empty())
-        .ok_or_else(|| DiscoveryError::Session("CONTENTdm metadata has no IIIF URL".into()))?;
-    let base = Url::parse(resource.final_uri())
-        .map_err(|_| DiscoveryError::Session("invalid CONTENTdm metadata URL".into()))?;
-    let origin = base.origin().ascii_serialization();
-    let uri = if Url::parse(&info_uri).is_ok() {
-        info_uri
-    } else if info_uri.starts_with("/digital/") {
-        format!("{origin}{info_uri}")
-    } else if info_uri.starts_with('/') {
-        format!("{origin}/digital{info_uri}")
-    } else {
-        format!("{origin}/digital/{info_uri}")
-    };
-    Ok(DiscoveryStep::Follow(Request::new(uri)))
-}
-
-fn contains_micrio_element(contents: &[u8]) -> bool {
-    MICRIO_CUSTOM_ELEMENT.is_match(contents)
-}
-
-fn follow_micrio_element(
-    _: &DiscoveryContext<'_>,
-    resource: DiscoveryResource<'_>,
-) -> Result<DiscoveryStep, DiscoveryError> {
-    let id = MICRIO_CUSTOM_ELEMENT
-        .captures(resource.bytes())
-        .and_then(|captures| captures.name("id"))
-        .map(|capture| std::str::from_utf8(capture.as_bytes()))
-        .transpose()
-        .map_err(|_| DiscoveryError::Session("Micrio custom element ID is not UTF-8".into()))?
-        .ok_or_else(|| DiscoveryError::Session("Micrio custom element lacks an ID".into()))?;
-    Ok(DiscoveryStep::Follow(Request::new(format!(
-        "https://i.micr.io/{id}/info.json"
-    ))))
 }
 
 fn catalog(uri: &str, contents: &[u8]) -> Result<ImageCatalog, DiscoveryError> {

--- a/dezoomify-core/src/iiif/mod.rs
+++ b/dezoomify-core/src/iiif/mod.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, LazyLock};
 use custom_error::custom_error;
 use regex::bytes::Regex as BytesRegex;
 use tile_info::ImageInfo;
+use url::Url;
 
 use crate::Vec2d;
 use crate::core::{
@@ -25,13 +26,22 @@ static MICRIO_CUSTOM_ELEMENT: LazyLock<BytesRegex> = LazyLock::new(|| {
 });
 
 const ROUTES: &[DiscoveryRoute] = &[
+    DiscoveryMatch::UrlPredicate(has_manifest_parameter).map_url(manifest_parameter),
+    DiscoveryMatch::UrlPredicate(is_onb_entry).map_url(onb_manifest),
+    DiscoveryMatch::UrlPredicate(is_contentdm_record).map_url(contentdm_metadata),
+    DiscoveryMatch::UrlPredicate(is_contentdm_metadata).then(follow_contentdm_info),
     DiscoveryMatch::ContentPredicate(contains_micrio_element).then(follow_micrio_element),
     DiscoveryMatch::Any.extract(catalog),
 ];
 
 /// IIIF dezoomer. See <https://iiif.io/>.
 pub const SPEC: DezoomerSpec = DezoomerSpec::new("iiif", ROUTES).preferring(|uri| {
-    uri.contains("info.json") || uri.contains("iiif") || uri.contains("manifest.json")
+    uri.contains("info.json")
+        || uri.contains("iiif")
+        || uri.contains("manifest.json")
+        || has_manifest_parameter(uri)
+        || is_onb_entry(uri)
+        || is_contentdm_record(uri)
 });
 
 /// Determines the best title for an image from IIIF manifest metadata
@@ -72,6 +82,119 @@ impl From<IIIFError> for DiscoveryError {
     fn from(err: IIIFError) -> Self {
         Self::Session(err.to_string())
     }
+}
+
+fn has_manifest_parameter(uri: &str) -> bool {
+    manifest_parameter_value(uri).is_some()
+}
+
+fn manifest_parameter(uri: &str) -> Result<Request, DiscoveryError> {
+    manifest_parameter_value(uri)
+        .map(Request::new)
+        .ok_or_else(|| DiscoveryError::Session("missing IIIF manifest parameter".into()))
+}
+
+fn manifest_parameter_value(uri: &str) -> Option<String> {
+    let url = Url::parse(uri).ok()?;
+    url.query_pairs()
+        .find_map(|(name, value)| (name == "manifest").then(|| value.into_owned()))
+        .or_else(|| {
+            url.fragment().and_then(|fragment| {
+                url::form_urlencoded::parse(fragment.trim_start_matches('?').as_bytes())
+                    .find_map(|(name, value)| (name == "manifest").then(|| value.into_owned()))
+            })
+        })
+        .filter(|value| !value.is_empty())
+}
+
+fn is_onb_entry(uri: &str) -> bool {
+    let Ok(url) = Url::parse(uri) else {
+        return false;
+    };
+    matches!(url.host_str(), Some("viewer.onb.ac.at"))
+        || matches!(url.host_str(), Some("digital.onb.ac.at"))
+            && url.path() == "/RepViewer/viewer.faces"
+            && url.query_pairs().any(|(name, _)| name == "doc")
+}
+
+fn onb_manifest(uri: &str) -> Result<Request, DiscoveryError> {
+    let url = Url::parse(uri).map_err(|_| DiscoveryError::Session("invalid ONB URL".into()))?;
+    let identifier = match url.host_str() {
+        Some("viewer.onb.ac.at") => url
+            .path_segments()
+            .and_then(|mut segments| segments.next())
+            .map(str::to_owned),
+        Some("digital.onb.ac.at") => url
+            .query_pairs()
+            .find_map(|(name, value)| (name == "doc").then(|| value.into_owned())),
+        _ => None,
+    }
+    .filter(|identifier| !identifier.is_empty())
+    .ok_or_else(|| DiscoveryError::Session("missing ONB document identifier".into()))?;
+    Ok(Request::new(format!(
+        "https://api.onb.ac.at/iiif/presentation/v3/manifest/{identifier}"
+    )))
+}
+
+fn is_contentdm_record(uri: &str) -> bool {
+    let Ok(url) = Url::parse(uri) else {
+        return false;
+    };
+    let segments = url.path_segments().map(Iterator::collect::<Vec<_>>);
+    matches!(segments.as_deref(), Some(["digital", "collection", _, "id", id, ..]) if id.parse::<u64>().is_ok())
+}
+
+fn contentdm_metadata(uri: &str) -> Result<Request, DiscoveryError> {
+    let url =
+        Url::parse(uri).map_err(|_| DiscoveryError::Session("invalid CONTENTdm URL".into()))?;
+    let segments = url
+        .path_segments()
+        .map(Iterator::collect::<Vec<_>>)
+        .ok_or_else(|| DiscoveryError::Session("invalid CONTENTdm path".into()))?;
+    let ["digital", "collection", collection, "id", identifier, ..] = segments.as_slice() else {
+        return Err(DiscoveryError::Session(
+            "invalid CONTENTdm record URL".into(),
+        ));
+    };
+    Ok(Request::new(format!(
+        "{}/digital/api/singleitem/collection/{collection}/id/{identifier}",
+        url.origin().ascii_serialization()
+    )))
+}
+
+fn is_contentdm_metadata(uri: &str) -> bool {
+    Url::parse(uri).is_ok_and(|url| {
+        matches!(
+            url.path_segments()
+                .map(Iterator::collect::<Vec<_>>)
+                .as_deref(),
+            Some(["digital", "api", "singleitem", "collection", _, "id", _])
+        )
+    })
+}
+
+fn follow_contentdm_info(
+    _: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let info_uri = serde_json::from_slice::<serde_json::Value>(resource.bytes())
+        .ok()
+        .and_then(|value| value.get("iiifInfoUri")?.as_str().map(str::to_owned))
+        .filter(|uri| !uri.is_empty())
+        .ok_or_else(|| DiscoveryError::Session("CONTENTdm metadata has no IIIF URL".into()))?;
+    let base = Url::parse(resource.final_uri())
+        .map_err(|_| DiscoveryError::Session("invalid CONTENTdm metadata URL".into()))?;
+    let origin = base.origin().ascii_serialization();
+    let uri = if Url::parse(&info_uri).is_ok() {
+        info_uri
+    } else if info_uri.starts_with("/digital/") {
+        format!("{origin}{info_uri}")
+    } else if info_uri.starts_with('/') {
+        format!("{origin}/digital{info_uri}")
+    } else {
+        format!("{origin}/digital/{info_uri}")
+    };
+    Ok(DiscoveryStep::Follow(Request::new(uri)))
 }
 
 fn contains_micrio_element(contents: &[u8]) -> bool {

--- a/dezoomify-core/src/iiif/mod.rs
+++ b/dezoomify-core/src/iiif/mod.rs
@@ -24,10 +24,10 @@ mod title_tests;
 
 const ROUTES: &[DiscoveryRoute] = &[
     DiscoveryMatch::UrlPredicate(has_manifest_parameter).map_url(manifest_parameter),
-    DiscoveryMatch::UrlPredicate(onb::is_entry).map_url(onb::manifest),
-    DiscoveryMatch::UrlPredicate(contentdm::is_record).map_url(contentdm::metadata),
-    DiscoveryMatch::UrlPredicate(contentdm::is_metadata).then(contentdm::follow_info),
-    DiscoveryMatch::ContentPredicate(micrio::contains_element).then(micrio::follow_element),
+    onb::ROUTE,
+    contentdm::RECORD_ROUTE,
+    contentdm::METADATA_ROUTE,
+    micrio::ROUTE,
     DiscoveryMatch::Any.extract(catalog),
 ];
 
@@ -37,8 +37,8 @@ pub const SPEC: DezoomerSpec = DezoomerSpec::new("iiif", ROUTES).preferring(|uri
         || uri.contains("iiif")
         || uri.contains("manifest.json")
         || has_manifest_parameter(uri)
-        || onb::is_entry(uri)
-        || contentdm::is_record(uri)
+        || onb::prefers(uri)
+        || contentdm::prefers(uri)
 });
 
 /// Determines the best title for an image from IIIF manifest metadata

--- a/dezoomify-core/src/iiif/onb.rs
+++ b/dezoomify-core/src/iiif/onb.rs
@@ -1,0 +1,32 @@
+use url::Url;
+
+use crate::core::{DiscoveryError, Request};
+
+pub(super) fn is_entry(uri: &str) -> bool {
+    let Ok(url) = Url::parse(uri) else {
+        return false;
+    };
+    matches!(url.host_str(), Some("viewer.onb.ac.at"))
+        || matches!(url.host_str(), Some("digital.onb.ac.at"))
+            && url.path() == "/RepViewer/viewer.faces"
+            && url.query_pairs().any(|(name, _)| name == "doc")
+}
+
+pub(super) fn manifest(uri: &str) -> Result<Request, DiscoveryError> {
+    let url = Url::parse(uri).map_err(|_| DiscoveryError::Session("invalid ONB URL".into()))?;
+    let identifier = match url.host_str() {
+        Some("viewer.onb.ac.at") => url
+            .path_segments()
+            .and_then(|mut segments| segments.next())
+            .map(str::to_owned),
+        Some("digital.onb.ac.at") => url
+            .query_pairs()
+            .find_map(|(name, value)| (name == "doc").then(|| value.into_owned())),
+        _ => None,
+    }
+    .filter(|identifier| !identifier.is_empty())
+    .ok_or_else(|| DiscoveryError::Session("missing ONB document identifier".into()))?;
+    Ok(Request::new(format!(
+        "https://api.onb.ac.at/iiif/presentation/v3/manifest/{identifier}"
+    )))
+}

--- a/dezoomify-core/src/iiif/onb.rs
+++ b/dezoomify-core/src/iiif/onb.rs
@@ -1,6 +1,12 @@
 use url::Url;
 
-use crate::core::{DiscoveryError, Request};
+use crate::core::{DiscoveryError, DiscoveryMatch, DiscoveryRoute, Request};
+
+pub(super) const ROUTE: DiscoveryRoute = DiscoveryMatch::UrlPredicate(is_entry).map_url(manifest);
+
+pub(super) fn prefers(uri: &str) -> bool {
+    is_entry(uri)
+}
 
 pub(super) fn is_entry(uri: &str) -> bool {
     let Ok(url) = Url::parse(uri) else {

--- a/dezoomify-core/testdata/coverage/iiif/contentdm-info.json
+++ b/dezoomify-core/testdata/coverage/iiif/contentdm-info.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/image/2/context.json",
+  "@id": "https://fixtures.test/digital/iiif/OKMaps/6483",
+  "width": 512,
+  "height": 512,
+  "tiles": [{ "width": 256, "height": 256, "scaleFactors": [1, 2] }],
+  "qualities": ["native"],
+  "formats": ["jpg"]
+}

--- a/dezoomify-core/testdata/coverage/iiif/contentdm-metadata.json
+++ b/dezoomify-core/testdata/coverage/iiif/contentdm-metadata.json
@@ -1,0 +1,4 @@
+{
+  "title": "Alfalfa County, Oklahoma",
+  "iiifInfoUri": "/iiif/OKMaps/6483/info.json"
+}

--- a/dezoomify-core/testdata/coverage/iiif/onb-manifest.json
+++ b/dezoomify-core/testdata/coverage/iiif/onb-manifest.json
@@ -1,0 +1,28 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37",
+  "type": "Manifest",
+  "items": [{
+    "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/canvas/1",
+    "type": "Canvas",
+    "items": [{
+      "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/page/1",
+      "type": "AnnotationPage",
+      "items": [{
+        "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/annotation/1",
+        "type": "Annotation",
+        "motivation": "painting",
+        "body": {
+          "id": "https://api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC/full/300,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [{
+            "id": "https://api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC",
+            "type": "ImageService3",
+            "profile": "level2"
+          }]
+        }
+      }]
+    }]
+  }]
+}

--- a/dezoomify-core/tests/dezoomer_coverage.rs
+++ b/dezoomify-core/tests/dezoomer_coverage.rs
@@ -478,6 +478,75 @@ fn dezoomer_iiif_plain_image_manifest_remains_deferred() {
 }
 
 #[test]
+fn dezoomer_iiif_url_adapters_follow_metadata() {
+    let manifest = coverage_fixture!("iiif/presentation-manifest.json");
+    for input in [
+        "https://fixtures.test/mirador?manifest=https%3A%2F%2Ffixtures.test%2Fiiif-presentation%2Fmanifest.json",
+        "https://fixtures.test/uv/#?manifest=https%3A%2F%2Ffixtures.test%2Fiiif-presentation%2Fmanifest.json",
+    ] {
+        let catalog = discover(
+            input,
+            &[(
+                "https://fixtures.test/iiif-presentation/manifest.json",
+                manifest,
+            )],
+        )
+        .unwrap();
+        let [CatalogEntry::Deferred(image)] = catalog.entries() else {
+            panic!("manifest adapter must produce one deferred image");
+        };
+        assert_eq!(
+            image.uri,
+            "https://fixtures.test/iiif-presentation/image/info.json"
+        );
+    }
+
+    for input in [
+        "https://viewer.onb.ac.at/10048A37/",
+        "https://viewer.onb.ac.at/10048A37/137",
+        "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37",
+        "https://digital.onb.ac.at/RepViewer/viewer.faces?doc=10048A37&order=1",
+    ] {
+        let catalog = discover(
+            input,
+            &[(
+                "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37",
+                coverage_fixture!("iiif/onb-manifest.json"),
+            )],
+        )
+        .unwrap();
+        let [CatalogEntry::Deferred(image)] = catalog.entries() else {
+            panic!("ONB adapter must produce one deferred image");
+        };
+        assert_eq!(
+            image.uri,
+            "https://api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC/info.json"
+        );
+    }
+
+    let input = "https://fixtures.test/digital/collection/OKMaps/id/6483/rec/6";
+    let image = ready_image(
+        discover(
+            input,
+            &[
+                (
+                    "https://fixtures.test/digital/api/singleitem/collection/OKMaps/id/6483",
+                    coverage_fixture!("iiif/contentdm-metadata.json"),
+                ),
+                (
+                    "https://fixtures.test/digital/iiif/OKMaps/6483/info.json",
+                    coverage_fixture!("iiif/contentdm-info.json"),
+                ),
+            ],
+        )
+        .unwrap(),
+    );
+    assert_eq!(image.format.as_str(), "iiif");
+    assert!(tile_urls(image.levels.last().unwrap()).iter().any(|url| url
+        == "https://fixtures.test/digital/iiif/OKMaps/6483/256,256,256,256/256,256/0/native.jpg"));
+}
+
+#[test]
 fn dezoomer_iipimage_query_case() {
     let input = "https://fixtures.test/iip?FIF=/image.tif";
     let metadata_input =

--- a/tests/live_dezoomers.rs
+++ b/tests/live_dezoomers.rs
@@ -1,4 +1,4 @@
-fn run_live_dezoomer(name: &str, url: &str) {
+fn run_live_dezoomer(name: &str, url: &str, extra_args: &[&str]) {
     if std::env::var_os("DEZOOMIFY_LIVE_TESTS").is_none() {
         return;
     }
@@ -6,7 +6,7 @@ fn run_live_dezoomer(name: &str, url: &str) {
     let temp_dir = tempfile::tempdir().unwrap();
     let output = temp_dir.path().join(format!("{name}.png"));
     let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_dezoomify-rs"));
-    command.args([url, output.to_str().unwrap(), "--max-width", "1000"]);
+    command.args([url, output.to_str().unwrap(), "--max-width", "1200"]);
     let result = command
         .args([
             "--retries",
@@ -20,6 +20,7 @@ fn run_live_dezoomer(name: &str, url: &str) {
             "--timeout",
             "30s",
         ])
+        .args(extra_args)
         .output()
         .unwrap();
     assert!(
@@ -32,10 +33,10 @@ fn run_live_dezoomer(name: &str, url: &str) {
 }
 
 macro_rules! live_dezoomer {
-    ($name:ident, $url:literal) => {
+    ($name:ident, $url:literal $(, $arg:literal)*) => {
         #[test]
         fn $name() {
-            run_live_dezoomer(stringify!($name), $url);
+            run_live_dezoomer(stringify!($name), $url, &[$($arg),*]);
         }
     };
 }
@@ -57,9 +58,15 @@ live_dezoomer!(
     iiif_csntm,
     "https://collections.csntm.org/image-service/iiif/MNTGRCGA01/default/M_NT_GRC_GA01_20250609_203r/M_NT_GRC_GA01_20250609_203r/info.json"
 );
+live_dezoomer!(iiif_onb_viewer, "https://viewer.onb.ac.at/10048A37/");
 live_dezoomer!(
-    iiif_onb_manifest,
-    "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37"
+    iiif_oklahoma_contentdm,
+    "https://dc.library.okstate.edu/digital/collection/OKMaps/id/6483/rec/6",
+    "--accept-invalid-certs"
+);
+live_dezoomer!(
+    iiif_liechtenstein_collections,
+    "https://www.liechtensteincollections.at/en/collections-online/forest-landscape"
 );
 live_dezoomer!(
     iiif_nls_auchinleck,


### PR DESCRIPTION
Adds declarative IIIF routes for Mirador and Universal Viewer manifest parameters, ONB viewer and RepViewer URLs, and CONTENTdm record discovery. Fixture coverage verifies every route reaches its expected IIIF metadata.\n\nFollow-up in #353 isolates the site-specific implementation and adds manually verified live coverage for ONB and Oklahoma CONTENTdm.\n\nValidation: cargo test --workspace; cargo fmt --check; cargo clippy --workspace --all-targets -- -D warnings.